### PR TITLE
refactor: make okhttp client initialise in constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ Temporary Items
 
 target/
 dependency-reduced-pom.xml
+
+pom.xml.versionsBackup
+sdk.iml

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,10 +52,12 @@
             <version>1.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.10.0</version>
         </dependency>
+
     </dependencies>
 </project>

--- a/core/src/main/java/io/keploy/regression/keploy/AppConfig.java
+++ b/core/src/main/java/io/keploy/regression/keploy/AppConfig.java
@@ -17,7 +17,7 @@ public class AppConfig {
     private String Port = "8080";
 
     private Duration Delay = Duration.ofSeconds(6);
-    private Duration Timeout = Duration.ofSeconds(100);
+    private Duration Timeout = Duration.ofSeconds(300);
     private Filter Filter;
 
     public AppConfig(String name, String host, String port, Duration delay, Duration timeout, Filter filter) {

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -51,6 +51,14 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.21.4</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.10.0</version>
+        </dependency>
+
+
     </dependencies>
 
     <properties>

--- a/integration/src/main/java/io/keploy/servlet/middleware.java
+++ b/integration/src/main/java/io/keploy/servlet/middleware.java
@@ -82,6 +82,12 @@ public class middleware extends HttpFilter {
                 }
                 //to stop after running all tests
                 countDownLatch.countDown(); // when running tests using cmd
+                try {
+                    Thread.sleep(10000);
+                    System.exit(0);
+                } catch (InterruptedException e) {
+                    logger.error("Failed to shut test run properly... ", e);
+                }
             }
         }).start();
     }
@@ -128,6 +134,7 @@ public class middleware extends HttpFilter {
 
         if (keploy_test_id != null) {
             k.getResp().put(keploy_test_id, simulateResponse);
+            Context.cleanup();
             logger.debug("response in keploy resp map: {} ", k.getResp().get(keploy_test_id));
         } else {
 

--- a/keploy-sdk/pom.xml
+++ b/keploy-sdk/pom.xml
@@ -106,6 +106,20 @@
             <version>6.0.53</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.21.4</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
+        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.10.0</version>
+        </dependency>
+
+
     </dependencies>
     <build>
         <resources>

--- a/keploy-sdk/src/main/resources/META-INF/MANIFEST.MF
+++ b/keploy-sdk/src/main/resources/META-INF/MANIFEST.MF
@@ -1,22 +1,22 @@
 Manifest-Version: 1.0
 Main-Class: 
-Class-Path: commons-io-2.6.jar error_prone_annotations-2.14.0.jar spring
- -aop-5.3.22.jar checker-qual-3.12.0.jar kotlin-stdlib-jdk7-1.5.31.jar j
- sr305-3.0.2.jar maven-shared-incremental-1.1.jar annotations-4.1.1.4.ja
- r grpc-netty-shaded-1.48.0.jar grpc-context-1.48.0.jar grpc-api-1.48.0.
- jar plexus-java-1.1.1.jar okhttp-4.10.0.jar guava-31.1-android.jar log4
- j-api-2.18.0.jar qdox-2.0.1.jar kotlin-stdlib-common-1.5.31.jar failure
- access-1.0.1.jar j2objc-annotations-1.3.jar grpc-protobuf-1.48.0.jar sp
- ring-beans-5.3.22.jar log4j-core-2.18.0.jar protobuf-java-3.21.4.jar pl
- exus-compiler-manager-2.11.1.jar listenablefuture-9999.0-empty-to-avoid
- -conflict-with-guava.jar perfmark-api-0.25.0.jar gson-2.9.0.jar proto-g
- oogle-common-protos-2.9.0.jar okio-jvm-3.0.0.jar maven-shared-utils-3.3
- .4.jar asm-9.2.jar javax.annotation-api-1.3.2.jar spring-web-5.3.22.jar
-  maven-compiler-plugin-3.10.1.jar spring-jcl-5.3.22.jar plexus-utils-3.
- 4.1.jar grpc-stub-1.48.0.jar animal-sniffer-annotations-1.21.jar annota
- tions-13.0.jar spring-context-5.3.22.jar kotlin-stdlib-jdk8-1.5.31.jar 
- plexus-compiler-api-2.11.1.jar spring-core-5.3.22.jar grpc-protobuf-lit
- e-1.48.0.jar kotlin-stdlib-1.6.20.jar plexus-component-annotations-1.5.
- 5.jar spring-expression-5.3.22.jar grpc-core-1.48.0.jar plexus-compiler
- -javac-2.11.1.jar
+Class-Path: grpc-protobuf-lite-1.48.0.jar gson-2.9.0.jar spring-web-5.3.
+ 22.jar kotlin-stdlib-1.6.20.jar log4j-api-2.18.0.jar maven-compiler-plu
+ gin-3.10.1.jar perfmark-api-0.25.0.jar spring-core-5.3.22.jar spring-co
+ ntext-5.3.22.jar grpc-protobuf-1.48.0.jar javax.annotation-api-1.3.2.ja
+ r okhttp-4.10.0.jar commons-io-2.6.jar asm-9.2.jar kotlin-stdlib-jdk7-1
+ .5.31.jar annotations-13.0.jar okio-jvm-3.0.0.jar maven-shared-utils-3.
+ 3.4.jar grpc-netty-shaded-1.48.0.jar plexus-utils-3.4.1.jar spring-aop-
+ 5.3.22.jar kotlin-stdlib-common-1.5.31.jar spring-beans-5.3.22.jar guav
+ a-31.1-android.jar spring-expression-5.3.22.jar error_prone_annotations
+ -2.14.0.jar plexus-component-annotations-1.5.5.jar plexus-compiler-java
+ c-2.11.1.jar grpc-core-1.48.0.jar checker-qual-3.12.0.jar proto-google-
+ common-protos-2.9.0.jar maven-shared-incremental-1.1.jar plexus-compile
+ r-manager-2.11.1.jar qdox-2.0.1.jar failureaccess-1.0.1.jar kotlin-stdl
+ ib-jdk8-1.5.31.jar protobuf-java-3.21.4.jar grpc-api-1.48.0.jar grpc-co
+ ntext-1.48.0.jar log4j-core-2.18.0.jar spring-jcl-5.3.22.jar plexus-jav
+ a-1.1.1.jar plexus-compiler-api-2.11.1.jar grpc-stub-1.48.0.jar annotat
+ ions-4.1.1.4.jar jsr305-3.0.2.jar listenablefuture-9999.0-empty-to-avoi
+ d-conflict-with-guava.jar animal-sniffer-annotations-1.21.jar j2objc-an
+ notations-1.3.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
             <version>2.18.0</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>

--- a/test-module/pom.xml
+++ b/test-module/pom.xml
@@ -18,31 +18,31 @@
 
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-<!--                <version>3.2.4</version>-->
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <transformers>
-                            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+<!--        <plugins>-->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-shade-plugin</artifactId>-->
+<!--&lt;!&ndash;                <version>3.2.4</version>&ndash;&gt;-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <phase>package</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>shade</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <transformers>-->
+<!--                            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">-->
 
-                                <mainClass>io.keploy.HelloWorld</mainClass>
-                            </transformer>
-                        </transformers>
-                        <createDependencyReducedPom>false</createDependencyReducedPom>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
+<!--                                <mainClass>io.keploy.HelloWorld</mainClass>-->
+<!--                            </transformer>-->
+<!--                        </transformers>-->
+<!--                        <createDependencyReducedPom>false</createDependencyReducedPom>-->
+<!--                    </configuration>-->
+<!--                </execution>-->
+<!--            </executions>-->
+<!--        </plugin>-->
 
-    </plugins>
+<!--    </plugins>-->
 </build>
 
         </project>


### PR DESCRIPTION
Currently we were creating new instance our client (`okhttp`) during each simulate call which caused breakdown of channel when tested at high concurrency like k6 . This caused incomplete test results .

Fix - Make http client static and accessible without initializing each an every time at function call .

Signed-off-by: Sarthak Shyngle <50234097+Sarthak160@users.noreply.github.com>

