### PR TITLE
fix: test case generation in test mode

### DIFF
--- a/agent/src/main/java/io/keploy/advice/ksql/RegisterDriverAdvice_Interceptor.java
+++ b/agent/src/main/java/io/keploy/advice/ksql/RegisterDriverAdvice_Interceptor.java
@@ -17,7 +17,6 @@ public class RegisterDriverAdvice_Interceptor {
 //        System.out.println("determineDriverClassName returns : " + s);
         if (s != null && !s.equals("io.keploy.ksql.KDriver")) {
             KDriver.DriverName = s;
-
             switch (s) {
                 case "org.postgresql.Driver":
                     KDriver.Dialect = "org.hibernate.dialect.PostgreSQLDialect";
@@ -27,6 +26,9 @@ public class RegisterDriverAdvice_Interceptor {
                     break;
                 case "oracle.jdbc.driver.OracleDriver":
                     KDriver.Dialect = "org.hibernate.dialect.OracleDialect";
+                    break;
+                case "org.h2.Driver":
+                    KDriver.Dialect = "org.hibernate.dialect.H2Dialect";
                     break;
                 default:
                     System.out.println("Dialect for driver: " + s + " is not supported yet");

--- a/integration/src/main/java/io/keploy/ksql/KConnection.java
+++ b/integration/src/main/java/io/keploy/ksql/KConnection.java
@@ -113,7 +113,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         switch (mode) {
             case MODE_TEST:
@@ -136,7 +135,6 @@ public class KConnection implements Connection {
             }
             return false;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         boolean rs = false;
         switch (mode) {
@@ -162,7 +160,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         switch (mode) {
             case MODE_TEST:
@@ -186,7 +183,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         switch (mode) {
             case MODE_TEST:
@@ -217,7 +213,6 @@ public class KConnection implements Connection {
             }
             return true;
         }
-        Mode.ModeType mode = kctx.getMode();
         boolean rs = true;
         switch (mode) {
             case MODE_TEST:
@@ -242,7 +237,6 @@ public class KConnection implements Connection {
             }
             return new KDatabaseMetaData(Mockito.mock(DatabaseMetaData.class));
         }
-        Mode.ModeType mode = kctx.getMode();
 
         DatabaseMetaData rs = null;
         switch (mode) {
@@ -268,7 +262,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         switch (mode) {
             case MODE_TEST:
@@ -288,11 +281,10 @@ public class KConnection implements Connection {
         Kcontext kctx = Context.getCtx();
         if (kctx == null) {
             if (mode == recordMode) {
-                wrappedCon.isReadOnly();
+                return wrappedCon.isReadOnly();
             }
-            return true;
+            return false;
         }
-        Mode.ModeType mode = kctx.getMode();
         boolean rs = false;
 
         switch (mode) {
@@ -318,7 +310,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
 
         switch (mode) {
@@ -352,7 +343,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         switch (mode) {
             case MODE_TEST:
@@ -375,7 +365,6 @@ public class KConnection implements Connection {
             }
             return 2;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         int rs = 2;
         switch (mode) {
@@ -401,7 +390,6 @@ public class KConnection implements Connection {
             }
             return null;
         }
-        Mode.ModeType mode = kctx.getMode();
         SQLWarning rs = null;
         switch (mode) {
             case MODE_TEST:
@@ -426,7 +414,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         switch (mode) {
             case MODE_TEST:
@@ -450,7 +437,6 @@ public class KConnection implements Connection {
             Statement resultSet = Mockito.mock(Statement.class);
             return new KStatement(resultSet);
         }
-        Mode.ModeType mode = kctx.getMode();
 
         Statement rs = new KStatement();
         switch (mode) {
@@ -476,7 +462,6 @@ public class KConnection implements Connection {
             }
         }
         assert kctx != null;
-        Mode.ModeType mode = kctx.getMode();
 
         PreparedStatement rs = new KPreparedStatement();
         switch (mode) {
@@ -503,7 +488,6 @@ public class KConnection implements Connection {
             CallableStatement resultSet = Mockito.mock(CallableStatement.class);
             return new KCallableStatement(resultSet);
         }
-        Mode.ModeType mode = kctx.getMode();
 
         CallableStatement rs = new KCallableStatement();
         switch (mode) {
@@ -528,7 +512,6 @@ public class KConnection implements Connection {
             }
             return null;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         Map<String, Class<?>> rs = null;
         switch (mode) {
@@ -555,7 +538,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
 
         switch (mode) {
@@ -580,7 +562,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         switch (mode) {
             case MODE_TEST:
@@ -603,7 +584,6 @@ public class KConnection implements Connection {
             }
             return 0;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         int rs = 0;
         switch (mode) {
@@ -640,7 +620,6 @@ public class KConnection implements Connection {
             }
             return;
         }
-        Mode.ModeType mode = kctx.getMode();
 
 
         switch (mode) {
@@ -670,7 +649,6 @@ public class KConnection implements Connection {
             Statement resultSet = Mockito.mock(Statement.class);
             return new KStatement(resultSet);
         }
-        Mode.ModeType mode = kctx.getMode();
 
         Statement rs = new KStatement();
         switch (mode) {
@@ -696,7 +674,6 @@ public class KConnection implements Connection {
             }
         }
         assert kctx != null;
-        Mode.ModeType mode = kctx.getMode();
 
         PreparedStatement rs = new KPreparedStatement();
         switch (mode) {
@@ -723,7 +700,6 @@ public class KConnection implements Connection {
             CallableStatement resultSet = Mockito.mock(CallableStatement.class);
             return new KCallableStatement(resultSet);
         }
-        Mode.ModeType mode = kctx.getMode();
 
         CallableStatement rs = new KCallableStatement();
         switch (mode) {
@@ -750,7 +726,6 @@ public class KConnection implements Connection {
             PreparedStatement resultSet = Mockito.mock(PreparedStatement.class);
             return new KPreparedStatement(resultSet);
         }
-        Mode.ModeType mode = kctx.getMode();
         PreparedStatement rs = new KPreparedStatement();
 
         switch (mode) {
@@ -777,7 +752,6 @@ public class KConnection implements Connection {
             }
         }
         assert kctx != null;
-        Mode.ModeType mode = kctx.getMode();
 
         PreparedStatement rs = new KPreparedStatement();
         switch (mode) {
@@ -803,7 +777,6 @@ public class KConnection implements Connection {
             }
         }
         assert kctx != null;
-        Mode.ModeType mode = kctx.getMode();
 
         PreparedStatement rs = new KPreparedStatement();
         switch (mode) {
@@ -849,7 +822,6 @@ public class KConnection implements Connection {
             }
             return true;
         }
-        Mode.ModeType mode = kctx.getMode();
 
         boolean rs = true;
         switch (mode) {

--- a/integration/src/main/java/io/keploy/ksql/KResultSet.java
+++ b/integration/src/main/java/io/keploy/ksql/KResultSet.java
@@ -105,6 +105,7 @@ public class KResultSet implements ResultSet {
         }
 
         TableData = testTable;
+//        System.out.println("Table: " + testTable);
     }
 
     // Used in test mode for extracting single row in the form of string from mocks
@@ -308,12 +309,30 @@ public class KResultSet implements ResultSet {
 
     @Override
     public float getFloat(int columnIndex) throws SQLException {
-        return wrappedResultSet.getFloat(columnIndex);
+        Kcontext kctx = Context.getCtx();
+        Mode.ModeType mode = kctx.getMode();
+        if (mode == Mode.ModeType.MODE_TEST) {
+            wasNull = false;
+            return Float.parseFloat(RowData.get(String.valueOf(columnIndex)));
+        }
+        Float gs = wrappedResultSet.getFloat(columnIndex);
+        RowDict.put(String.valueOf(columnIndex), String.valueOf(gs));
+        addSqlColToList(String.valueOf(columnIndex), gs.getClass().getSimpleName());
+        return gs;
     }
 
     @Override
     public double getDouble(int columnIndex) throws SQLException {
-        return wrappedResultSet.getDouble(columnIndex);
+        Kcontext kctx = Context.getCtx();
+        Mode.ModeType mode = kctx.getMode();
+        if (mode == Mode.ModeType.MODE_TEST) {
+            wasNull = false;
+            return Double.parseDouble(RowData.get(String.valueOf(columnIndex)));
+        }
+        Double gs = wrappedResultSet.getDouble(columnIndex);
+        RowDict.put(String.valueOf(columnIndex), String.valueOf(gs));
+        addSqlColToList(String.valueOf(columnIndex), gs.getClass().getSimpleName());
+        return gs;
     }
 
     @Override
@@ -620,12 +639,30 @@ public class KResultSet implements ResultSet {
 
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-        return wrappedResultSet.getBigDecimal(columnIndex);
+        Kcontext kctx = Context.getCtx();
+        Mode.ModeType mode = kctx.getMode();
+        if (mode == Mode.ModeType.MODE_TEST) {
+            wasNull = false;
+            return new BigDecimal(Double.parseDouble(RowData.get(String.valueOf(columnIndex))));
+        }
+        BigDecimal gs = wrappedResultSet.getBigDecimal(columnIndex);
+        RowDict.put(String.valueOf(columnIndex), String.valueOf(gs));
+        addSqlColToList(String.valueOf(columnIndex), gs.getClass().getSimpleName());
+        return gs;
     }
 
     @Override
     public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
-        return wrappedResultSet.getBigDecimal(columnLabel);
+        Kcontext kctx = Context.getCtx();
+        Mode.ModeType mode = kctx.getMode();
+        if (mode == Mode.ModeType.MODE_TEST) {
+            wasNull = false;
+            return new BigDecimal(Double.parseDouble(RowData.get(columnLabel)));
+        }
+        BigDecimal gl = wrappedResultSet.getBigDecimal(columnLabel);
+        RowDict.put(columnLabel, String.valueOf(gl));
+        addSqlColToList(columnLabel, gl.getClass().getSimpleName());
+        return gl;
     }
 
     @Override

--- a/integration/src/main/java/io/keploy/servlet/KeployMiddleware.java
+++ b/integration/src/main/java/io/keploy/servlet/KeployMiddleware.java
@@ -204,7 +204,7 @@ public class KeployMiddleware implements Filter {
             kctx.setTestId(keploy_test_id);
             kctx.setMode(Mode.ModeType.MODE_TEST);
             List<Service.Mock> mocks = k.getMocks().get(keploy_test_id);
-            if (mocks!=null){
+            if (mocks != null) {
                 kctx.getMock().addAll(mocks);
             }
         }
@@ -256,6 +256,11 @@ public class KeployMiddleware implements Filter {
             InternalThreadLocalMap.remove();
             logger.debug("response in keploy resp map: {}", k.getResp().get(keploy_test_id));
         } else {
+            Mode.ModeType mode = Mode.getMode();
+            // to prevent recording testcases in test mode.
+            if (mode != null && mode.equals(Mode.ModeType.MODE_TEST)) {
+                return;
+            }
 
             Map<String, String> urlParams = setUrlParams(requestWrapper.getParameterMap());
 


### PR DESCRIPTION
Signed-off-by: gouravkrosx <gouravgreatkr@gmail.com>

1. When running keploy tests using the test file along with other unit test cases, java-sdk was generating test cases, this happened because when unit test cases run, the flow goes to the controller hence in the middleware of keploy.
2. Also mocks some methods in KResultset. For eg: getBigDecimal(int columnIdx), getDouble(int columnIdx) etc.  