### PR TITLE
fix: add apache response headers during test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ or to *build.gradle*:
     - `KEPLOY_ASSET_PATH`        (default **/src/test/e2e/assets** directory of your application)
     - `DENOISE`            (default DENOISE = false)
       **Note:** By enabling denoise, it will filter out noisy fields for the testcase.
-    - `RUN_TEST_BEFORE_RECORD` (default RUN_TEST_BEFORE_RECORD = true)
-      **Note:** Default is true, to maintain the same database state.
+    - `RUN_TEST_BEFORE_RECORD` (default RUN_TEST_BEFORE_RECORD = false)
+      **Note:** It is used to maintain the same database state.
 
 
 - **Generate testcases**

--- a/agent/src/main/java/io/keploy/agent/KAgent.java
+++ b/agent/src/main/java/io/keploy/agent/KAgent.java
@@ -1,5 +1,7 @@
 package io.keploy.agent;
 
+import io.keploy.classLoader.CustomClassLoader;
+import io.keploy.classLoader.KClassLoader;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
@@ -214,6 +216,60 @@ public class KAgent {
                     return builder.constructor(takesArgument(0, DatabaseMetaData.class)).intercept(Advice.to(TypePool.Default.ofSystemLoader().describe("io.keploy.advice.ksql.DataBaseMetaData_Advice").resolve(), ClassFileLocator.ForClassLoader.ofSystemLoader()));
                 }))
                 .installOn(instrumentation);
+//
+//        try {
+//            // Assuming you have a File object representing the .jar file
+//            File jarFile = new File("/Users/gouravkumar/Desktop/Keploy/KPOCs/google-map-spring-boot-starter/target/google-map-spring-boot-starter-0.0.1-SNAPSHOT.jar");
+//
+//// Open the jar file
+//            JarFile jar = new JarFile(jarFile);
+//
+//// Get the manifest
+//            Manifest manifest = jar.getManifest();
+//            Manifest mf = new Manifest();
+//            mf.read(Files.newInputStream(new File("/Users/gouravkumar/Desktop/Keploy/KPOCs/google-map-spring-boot-starter/src/main/resources/META-INF/MANIFEST.MF").toPath()));
+//
+//// Get the main attributes of the manifest
+////            Attributes mainAttribs = manifest.getMainAttributes();
+//            Attributes mainAttribs = mf.getMainAttributes();
+//
+//// Iterate through the main attributes and print their names and values
+//            for (Map.Entry<Object, Object> entry : mainAttribs.entrySet()) {
+//                System.out.println(entry.getKey() + ": " + entry.getValue());
+//            }
+//
+//// Close the jar file
+//            jar.close();
+//        } catch (IOException e) {
+//            System.out.println("Jar Closed");
+//            throw new RuntimeException(e);
+//        }
+
+//        String dir = "/Users/gouravkumar/Desktop/Keploy/Keploy-SDKs/java-sdk/integration/target/classes";
+//        ClassLoader okhttpCl = new CustomClassLoader(dir);
+//        try {
+//            String googleInterceptorClass = "io.keploy.googleMaps.GoogleMapsInterceptor";
+//            System.out.println("flow goes here");
+//            Class<?> clazz = Class.forName(googleInterceptorClass, true, okhttpCl);
+////            Class<?> clazz = Class.forName(googleInterceptorClass, true,null);
+//        } catch (ClassNotFoundException e) {
+//            System.out.println("Class not found: " + e);
+//        }
+
+//        String dir = "/Users/gouravkumar/Desktop/Keploy/Keploy-SDKs/java-sdk/integration/target/classes/io/keploy/googleMaps/GoogleMapsInterceptor.class";
+//
+//        try {
+//            KClassLoader kClassLoader = new KClassLoader(Thread.currentThread().getContextClassLoader().getParent());
+//            String clazzz = "io.keploy.googleMaps.GoogleMapsInterceptor";
+//            KClassLoader.classPathMap.put(clazzz, dir);
+//            Class<?> gMapsCl = kClassLoader.loadClass(clazzz);
+//            ClassLoader gcl = gMapsCl.getClassLoader();
+//            System.out.println("google maps classloader: " + gcl);
+//            System.out.println("Current classloader:" + KAgent.class.getClassLoader());
+//        } catch (ClassNotFoundException e) {
+//            System.out.println("Class Not found: " + e);
+//        }
+
     }
 
     private static boolean isJUnitTest() {

--- a/agent/src/main/java/io/keploy/agent/KAgent.java
+++ b/agent/src/main/java/io/keploy/agent/KAgent.java
@@ -1,7 +1,5 @@
 package io.keploy.agent;
 
-import io.keploy.classLoader.CustomClassLoader;
-import io.keploy.classLoader.KClassLoader;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,5 +51,11 @@
             <artifactId>grpc-core</artifactId>
             <version>1.49.2</version>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.squareup.okhttp3</groupId>-->
+<!--            <artifactId>okhttp</artifactId>-->
+<!--            &lt;!&ndash;            <version>4.10.0</version>&ndash;&gt;-->
+<!--            <version>3.14.9</version>-->
+<!--        </dependency>-->
     </dependencies>
 </project>

--- a/api/src/main/java/io/keploy/service/GrpcService.java
+++ b/api/src/main/java/io/keploy/service/GrpcService.java
@@ -178,6 +178,7 @@ public class GrpcService {
         Service.TestCase testCase = testCaseBuilder.build();
 
         Service.HttpResp resp2 = simulate(testCase);
+//        Service.HttpResp resp2 = simulateOld(testCase);
 
         logger.debug("response got from simulate request: {}", resp2);
 
@@ -698,7 +699,7 @@ public class GrpcService {
 //                if (!paths.isEmpty()) {
 //                    for (String path : paths) {
 //                        File file = new File(path);
-//                        requestBodyBuilder.addFormDataPart(part.getKey(), file.getName(), RequestBody.create(file, MediaType.parse("text/plain")));
+//                        requestBodyBuilder.addFormDataPart(part.getKey(), file.getName(), RequestBody.create(MediaType.parse("text/plain"), file));
 //                    }
 //                } else if (!vals.isEmpty()) {
 //                    for (String val : vals) {

--- a/core/src/main/java/io/keploy/regression/keploy/Keploy.java
+++ b/core/src/main/java/io/keploy/regression/keploy/Keploy.java
@@ -36,6 +36,7 @@ public class Keploy {
                 envMode = System.getenv("KEPLOY_MODE");
             }
 
+            envMode = envMode.trim();
 
             switch (envMode) {
                 case "record":

--- a/integration/src/main/java/io/keploy/servlet/KeployMiddleware.java
+++ b/integration/src/main/java/io/keploy/servlet/KeployMiddleware.java
@@ -47,16 +47,19 @@ public class KeployMiddleware implements Filter {
         Config cfg = new Config();
         AppConfig appConfig = new AppConfig();
         if (System.getenv("APP_NAME") != null) {
-            appConfig.setName(System.getenv("APP_NAME"));
+            String app_name = System.getenv("APP_NAME").trim();
+            appConfig.setName(app_name);
         }
         if (System.getenv("APP_PORT") != null) {
-            appConfig.setPort(System.getenv("APP_PORT"));
+            String app_port = System.getenv("APP_PORT").trim();
+            appConfig.setPort(app_port);
         }
 
         //Path for exported tests
         String kpath = System.getenv("KEPLOY_TEST_PATH");
         Path path = Paths.get("");
         if (kpath != null && kpath.length() > 0 && !Paths.get(kpath).isAbsolute()) {
+            kpath = kpath.trim();
             Path effectivePath = path.resolve(kpath).toAbsolutePath();
             String absolutePath = effectivePath.normalize().toString();
             appConfig.setTestPath(absolutePath);
@@ -74,6 +77,7 @@ public class KeployMiddleware implements Filter {
         String mpath = System.getenv("KEPLOY_MOCK_PATH");
 
         if (mpath != null && mpath.length() > 0 && !Paths.get(mpath).isAbsolute()) {
+            mpath = mpath.trim();
             Path effectivePath = path.resolve(mpath).toAbsolutePath();
             String absolutePath = effectivePath.normalize().toString();
             appConfig.setMockPath(absolutePath);
@@ -92,6 +96,7 @@ public class KeployMiddleware implements Filter {
         String apath = System.getenv("KEPLOY_ASSET_PATH");
 
         if (apath != null && apath.length() > 0 && !Paths.get(apath).isAbsolute()) {
+            apath = apath.trim();
             Path effectivePath = path.resolve(apath).toAbsolutePath();
             String absolutePath = effectivePath.normalize().toString();
             appConfig.setAssetPath(absolutePath);
@@ -108,11 +113,13 @@ public class KeployMiddleware implements Filter {
         ServerConfig serverConfig = new ServerConfig();
 
         if (System.getenv("DENOISE") != null) {
-            serverConfig.setDenoise(Boolean.parseBoolean(System.getenv("DENOISE")));
+            String denoise = System.getenv("DENOISE").trim();
+            serverConfig.setDenoise(Boolean.parseBoolean(denoise));
         }
 
         if (System.getenv("KEPLOY_URL") != null) {
-            serverConfig.setURL(System.getenv("KEPLOY_URL"));
+            String keploy_url = System.getenv("KEPLOY_URL").trim();
+            serverConfig.setURL(keploy_url);
         }
 
         cfg.setApp(appConfig);
@@ -157,7 +164,7 @@ public class KeployMiddleware implements Filter {
         }
 
         String runTestBeforeRecord = System.getenv("RUN_TEST_BEFORE_RECORD");
-        boolean runTests = true;
+        boolean runTests = false;
         if (runTestBeforeRecord != null) {
             runTests = Boolean.parseBoolean(runTestBeforeRecord);
         }


### PR DESCRIPTION
- Inside Apache HttpClient Interceptor, response headers were not getting stored.
- Set default value of `RUN_TEST_BEFORE_RECORD` = false

Signed-off-by: gouravkrosx <gouravgreatkr@gmail.com>