### PR TITLE
redis support for java sdk

### DIFF
--- a/agent/src/main/java/io/keploy/advice/redis/jedis/JedisPoolResource_Advice.java
+++ b/agent/src/main/java/io/keploy/advice/redis/jedis/JedisPoolResource_Advice.java
@@ -1,0 +1,60 @@
+package io.keploy.advice.redis.jedis;
+
+import io.keploy.regression.Mode;
+import io.keploy.regression.context.Context;
+import io.keploy.regression.context.Kcontext;
+import net.bytebuddy.asm.Advice;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.util.Objects;
+
+import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
+
+/**
+ * Class {@link JedisPoolResource_Advice} is used for intercepting method {@link JedisPool#getResource()} and returning
+ * {@link Jedis} object when Keploy is in TEST_MODE.
+ *
+ * @author charankamarapu
+ */
+public class JedisPoolResource_Advice {
+
+    /**
+     * This method gets executed before the method {@link JedisPool#getResource()}. Based on the mode of Kelpoy it skips
+     * the invocation of the method {@link JedisPool#getResource()}
+     *
+     * @skipOn {@link Advice.OnNonDefaultValue} - this indicates that if any other value except default value of the
+     *           return type is returned then skip method invocation of intercepting method i.e.
+     *           {@link JedisPool#getResource()}
+     * @return Boolean - Default value false
+     */
+    @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+    static boolean enterMethods() {
+        final Logger logger = LoggerFactory.getLogger(JedisPoolResource_Advice.class);
+        Kcontext kCtx = Context.getCtx();
+        if (Objects.isNull(kCtx)) {
+            logger.debug("Keploy context is null");
+            return false;
+        } else {
+            return kCtx.getMode().equals(Mode.ModeType.MODE_TEST);
+        }
+    }
+
+    /**
+     * This method gets executed after intercepting method {@link JedisPool#getResource()} irrespective of invocation of
+     * intercepting method. Based on the return value of the {@link JedisPoolResource_Advice#enterMethods()} it provides
+     * {@link Jedis} object as return value to the intercepting method.
+     *
+     * @param returned - the return object for intercepting method
+     * @param enter - the value returned from {@link JedisPoolResource_Advice#enterMethods()}
+     */
+    @Advice.OnMethodExit()
+    static void enterMethods(@Advice.Return(readOnly = false, typing = DYNAMIC) Object returned,
+                             @Advice.Enter boolean enter ) {
+        if(enter){
+           returned =  new Jedis();
+        }
+    }
+}

--- a/agent/src/main/java/io/keploy/agent/KAgent.java
+++ b/agent/src/main/java/io/keploy/agent/KAgent.java
@@ -3,23 +3,32 @@ package io.keploy.agent;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.dynamic.scaffold.TypeValidation;
 import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.signature.SignatureReader;
+import net.bytebuddy.jar.asm.signature.SignatureVisitor;
+import net.bytebuddy.jar.asm.signature.SignatureWriter;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.pool.TypePool;
+import net.bytebuddy.utility.OpenedClassReader;
 import org.apache.http.HttpResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import net.bytebuddy.dynamic.DynamicType.Builder;
 
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Field;
 import java.sql.DatabaseMetaData;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 
 import static net.bytebuddy.matcher.ElementMatchers.*;
@@ -213,8 +222,27 @@ public class KAgent {
                     logger.debug("Inside DatabaseMetaData transformer");
                     return builder.constructor(takesArgument(0, DatabaseMetaData.class)).intercept(Advice.to(TypePool.Default.ofSystemLoader().describe("io.keploy.advice.ksql.DataBaseMetaData_Advice").resolve(), ClassFileLocator.ForClassLoader.ofSystemLoader()));
                 }))
+                /*
+                  Intercepting getResource method of JedisPool. getResource is a method where the redis client(Jedis)
+                  returns a Jedis object and also checks the connection with the server. As connection should not be
+                  established when Keploy is in TEST_MODE this method should be intercepted and return a Jedis object
+                  without checking connection.
+                 */
+                .type(named("redis.clients.jedis.JedisPool"))
+                .transform(((builder, typeDescription, classLoader, module, protectionDomain) -> {
+                    return builder.method(named("getResource")).intercept(Advice.to(TypePool.Default.ofSystemLoader().describe("io.keploy.advice.redis.jedis.JedisPoolResource_Advice").resolve(), ClassFileLocator.ForClassLoader.ofSystemLoader()));
+                }))
+                /*
+                  The whole logic and connection with Redis Server boils down to one Class that is Connection. But
+                  Connection is not directly used rather used as a super class for a Class BinaryClient. This
+                  interceptor wraps the super class of BinaryClient i.e. Connection . As a final result BinaryClient
+                  will be extended to a wrapped class of Connection.
+                 */
+                .type(named("redis.clients.jedis.BinaryClient"))
+                .transform(((builder, typeDescription, classLoader, module, protectionDomain) -> {
+                    return getBuilderForClassWrapper(builder,"redis/clients/jedis/Connection","io/keploy/redis/jedis/KConnection");
+                }))
                 .installOn(instrumentation);
-//
 //        try {
 //            // Assuming you have a File object representing the .jar file
 //            File jarFile = new File("/Users/gouravkumar/Desktop/Keploy/KPOCs/google-map-spring-boot-starter/target/google-map-spring-boot-starter-0.0.1-SNAPSHOT.jar");
@@ -304,6 +332,101 @@ public class KAgent {
                 }
             }
         }
+    }
+
+    // A class will be replaced by another class using this builder
+    private static Builder getBuilderForClassWrapper(Builder builder, String host , String guest) {
+        return builder.visit(
+                new AsmVisitorWrapper() {
+                    @Override
+                    public int mergeWriter(int arg0) {
+                        return arg0;
+                    }
+
+                    @Override
+                    public int mergeReader(int arg0) {
+                        return arg0;
+                    }
+
+                    @Override
+                    public ClassVisitor wrap(TypeDescription instrumentedType,
+                                             ClassVisitor classVisitor,
+                                             net.bytebuddy.implementation.Implementation.Context implementationContext,
+                                             TypePool typePool,
+                                             FieldList<FieldDescription.InDefinedShape> fields,
+                                             MethodList<?> methods,
+                                             int writerFlags,
+                                             int readerFlags) {
+                        return new ClassVisitor(OpenedClassReader.ASM_API, classVisitor) {
+                            private boolean wasMarked = false;
+
+                            @Override
+                            public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                                if (host.equals(superName)) {
+                                    superName = guest;
+                                    if (signature != null) {
+                                        SignatureWriter sw = new SignatureWriter() {
+                                            private boolean superclass = false;
+
+                                            @Override
+                                            public void visitFormalTypeParameter(String name) {
+                                                superclass = false;
+                                                super.visitFormalTypeParameter(name);
+                                            }
+
+                                            @Override
+                                            public SignatureVisitor visitSuperclass() {
+                                                superclass = true;
+                                                return super.visitSuperclass();
+                                            }
+
+                                            @Override
+                                            public void visitEnd() {
+                                                superclass = false;
+                                                super.visitEnd();
+                                            }
+
+                                            @Override
+                                            public SignatureVisitor visitInterface() {
+                                                superclass = false;
+                                                return super.visitInterface();
+                                            }
+
+                                            @Override
+                                            public void visitClassType(String name) {
+                                                if (superclass && host.equals(name)) {
+                                                    name = guest;
+                                                }
+                                                super.visitClassType(name);
+                                            }
+                                        };
+                                        new SignatureReader(signature).accept(sw);
+                                        signature = sw.toString();
+                                    }
+                                    wasMarked = true;
+                                }
+                                super.visit(version, access, name, signature, superName, interfaces);
+                            }
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                                if (wasMarked && "<init>".equals(name)) {
+                                    return new MethodVisitor(OpenedClassReader.ASM_API, super.visitMethod(access, name, descriptor, signature, exceptions)) {
+                                        @Override
+                                        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                                            if (host.equals(owner)) {
+                                                owner = guest;
+                                            }
+                                            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                                        }
+                                    };
+                                }
+                                return super.visitMethod(access, name, descriptor, signature, exceptions);
+                            }
+                        };
+                    }
+                }
+        );
     }
 
 }

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -113,6 +113,22 @@
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+            <version>2.0.5.RELEASE</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/redis.clients/jedis -->
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.9.3</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/integration/src/main/java/io/keploy/redis/jedis/KConnection.java
+++ b/integration/src/main/java/io/keploy/redis/jedis/KConnection.java
@@ -1,0 +1,545 @@
+package io.keploy.redis.jedis;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.keploy.grpc.stubs.Service;
+import io.keploy.regression.KeployInstance;
+import io.keploy.regression.Mock;
+import io.keploy.regression.Mode;
+import io.keploy.regression.context.Context;
+import io.keploy.regression.context.Kcontext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.Protocol;
+import redis.clients.util.SafeEncoder;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+import java.lang.reflect.Type;
+import java.net.Socket;
+import java.util.*;
+
+/**
+ * KConnection is a class which extends Connection class and wraps it. KConnection records data in record mode and sends
+ * data in test mode.
+ */
+public class KConnection extends Connection {
+
+    static final Logger logger = LoggerFactory.getLogger(KConnection.class);
+    private final Mode.ModeType keployMode = Context.getCtx().getMode().getModeFromContext();
+    private Map<String, String> meta = new HashMap<String,String>() {
+        {
+            put("name", "redis");
+            put("type", "NoSqlDB");
+        }
+    };
+    private static final JdkSerializationRedisSerializer jdkSerializationRedisSerializer = new JdkSerializationRedisSerializer();
+    private static final Gson gson = new Gson();
+    private static final String CROSS = new String(Character.toChars(0x274C));
+    private static final byte[][] EMPTY_ARGS = new byte[0][];
+
+    public KConnection() {
+        super();
+        // fill data in Mock object into meta if application is in test mode.
+        if (keployMode == Mode.ModeType.MODE_TEST){
+            fillMock();
+        }
+    }
+
+    public KConnection(String host) {
+        super(host);
+        // fill data in Mock object into meta if application is in test mode.
+        if (keployMode == Mode.ModeType.MODE_TEST){
+            fillMock();
+        }
+    }
+
+    public KConnection(String host, int port) {
+        super(host, port);
+        // fill data in Mock object into meta if application is in test mode.
+        if (keployMode == Mode.ModeType.MODE_TEST){
+            fillMock();
+        }
+    }
+
+    public KConnection(String host, int port, boolean ssl) {
+        super(host, port, ssl);
+        // fill data in Mock object into meta if application is in test mode.
+        if (keployMode == Mode.ModeType.MODE_TEST){
+            fillMock();
+        }
+    }
+
+    public KConnection(String host, int port, boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters, HostnameVerifier hostnameVerifier) {
+        super(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+        // fill data in Mock object into meta if application is in test mode.
+        if (keployMode == Mode.ModeType.MODE_TEST){
+            fillMock();
+        }
+    }
+
+    @Override
+    public Socket getSocket() {
+        return super.getSocket();
+    }
+
+    @Override
+    public int getConnectionTimeout() {
+        return super.getConnectionTimeout();
+    }
+
+    @Override
+    public int getSoTimeout() {
+        return super.getSoTimeout();
+    }
+
+    @Override
+    public void setConnectionTimeout(int connectionTimeout) {
+        super.setConnectionTimeout(connectionTimeout);
+    }
+
+    @Override
+    public void setSoTimeout(int soTimeout) {
+        super.setSoTimeout(soTimeout);
+    }
+
+    @Override
+    public void setTimeoutInfinite() {
+        super.setTimeoutInfinite();
+    }
+
+    @Override
+    public void rollbackTimeout() {
+        super.rollbackTimeout();
+    }
+
+    @Override
+    protected Connection sendCommand(Protocol.Command cmd, String... args) {
+        switch (keployMode) {
+            case MODE_RECORD:
+                /*
+                  if the request has reached this function it means that request did not send byte data instead request
+                  sent objects. So Redis uses its default serializer to serialize the data.
+                 */
+                meta.put("serializer", SerializationType.REDIS_SERIALIZATION.toString());
+                // capturing request data
+                meta.put("command", cmd.toString());
+                int argCount = 1;
+                for (String arg : args) {
+                    meta.put("arg".concat(Integer.toString(argCount)), arg);
+                    argCount++;
+                }
+                return super.sendCommand(cmd, args);
+            case MODE_TEST:
+                /*
+                  Implementing super class logic and calling function of this class. So the flow doesn't divert
+                  completely to Connection class.
+                 */
+                byte[][] bargs = new byte[args.length][];
+                for(int i = 0; i < args.length; ++i) {
+                    bargs[i] = SafeEncoder.encode(args[i]);
+                }
+                return this.sendCommand(cmd, bargs);
+            default:
+                return super.sendCommand(cmd, args);
+        }
+    }
+
+    @Override
+    protected Connection sendCommand(Protocol.Command cmd) {
+        /*
+          Implementing super class logic and calling function of this class. So the flow doesn't divert
+          completely to Connection class.
+         */
+        return this.sendCommand(cmd,EMPTY_ARGS);
+    }
+
+    @Override
+    protected Connection sendCommand(Protocol.Command cmd, byte[]... args) {
+        switch (keployMode) {
+            case MODE_RECORD:
+                /*
+                  Checking if serializer is already set if not that means request sent bytes data i.e. before reaching
+                  redis client serialization is done. As JDK_REDIS_SERIALIZATION is the most used serializer using this
+                  serializer.
+                 */
+                if (!meta.containsKey("serializer") || !Objects.equals(meta.get("serializer"), SerializationType.REDIS_SERIALIZATION.toString())) {
+                    meta.put("serializer", SerializationType.JDK_REDIS_SERIALIZATION.toString());
+                    // capturing data
+                    meta.put("command", cmd.toString());
+                    int argCount = 1;
+                    for (byte[] arg : args) {
+                        Object deserializedObject = jdkSerializationRedisSerializer.deserialize(arg);
+                        meta.put("arg".concat(Integer.toString(argCount)), gson.toJson(deserializedObject));
+                        argCount++;
+                    }
+                }
+                return super.sendCommand(cmd, args);
+            case MODE_TEST:
+                /*
+                  Returning this class instead of Connection
+                 */
+                return this;
+            default:
+                return super.sendCommand(cmd, args);
+        }
+    }
+
+    @Override
+    public String getHost() {
+        return super.getHost();
+    }
+
+    @Override
+    public void setHost(String host) {
+        super.setHost(host);
+    }
+
+    @Override
+    public int getPort() {
+        return super.getPort();
+    }
+
+    @Override
+    public void setPort(int port) {
+        super.setPort(port);
+    }
+
+    @Override
+    public void connect() {
+        switch (keployMode) {
+            case MODE_TEST:
+                // does nothing
+                break;
+            default:
+                super.connect();
+        }
+    }
+
+    @Override
+    public void close() {
+        this.disconnect();
+    }
+
+    @Override
+    public void disconnect() {
+        switch (keployMode) {
+            case MODE_TEST:
+                break;
+                // does nothing
+            default:
+                super.disconnect();
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        return super.isConnected();
+    }
+
+    @Override
+    public String getStatusCodeReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // capturing data
+                String statusCodeReply = super.getStatusCodeReply();
+                meta.put("response", statusCodeReply);
+                sendToServer();
+                return statusCodeReply;
+            case MODE_TEST:
+                // returning recorded data
+                return meta.get("response");
+            default:
+                return super.getStatusCodeReply();
+        }
+    }
+
+    @Override
+    public String getBulkReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // capturing data
+                String bulkReply = super.getBulkReply();
+                meta.put("response", bulkReply);
+                sendToServer();
+                return bulkReply;
+            case MODE_TEST:
+                // returning recorded data
+                return meta.get("response");
+            default:
+                return super.getBulkReply();
+        }
+    }
+
+    @Override
+    public byte[] getBinaryBulkReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                /*
+                  Checking if serializer is already set if not that means request sent bytes data i.e. before reaching
+                  redis client serialization is done. As JDK_REDIS_SERIALIZATION is the most used serializer using this
+                  serializer.
+                 */
+                if (Objects.equals(meta.get("serializer"), SerializationType.REDIS_SERIALIZATION.toString())) {
+                    return super.getBinaryBulkReply();
+                } else {
+                    // capturing data
+                    byte[] binaryBulkReply = super.getBinaryBulkReply();
+                    Object deserializedObject = jdkSerializationRedisSerializer.deserialize(binaryBulkReply);
+                    meta.put("response", gson.toJson(deserializedObject));
+                    sendToServer();
+                    return binaryBulkReply;
+                }
+            case MODE_TEST:
+                // returning recorded data based on serializer
+                if (!Objects.equals(meta.get("serializer"), SerializationType.REDIS_SERIALIZATION.toString())) {
+                    return jdkSerializationRedisSerializer.serialize(gson.fromJson(meta.get("response"), Object.class));
+                }
+                return super.getBinaryBulkReply();
+            default:
+                return super.getBinaryBulkReply();
+        }
+    }
+
+    @Override
+    public Long getIntegerReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                Long integerReply = super.getIntegerReply();
+                meta.put("response", integerReply.toString());
+                sendToServer();
+                return integerReply;
+            case MODE_TEST:
+                // sending recorded data
+                return Long.parseLong(meta.get("response"));
+            default:
+                return super.getIntegerReply();
+        }
+    }
+
+    @Override
+    public List<String> getMultiBulkReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                List<String> multiBulkReply = super.getMultiBulkReply();
+                meta.put("response", multiBulkReply.toString());
+                sendToServer();
+                return multiBulkReply;
+            case MODE_TEST:
+                // sending recorded data
+                return new ArrayList<String>(Arrays.asList(meta.get("response").split(",")));
+            default:
+                return super.getMultiBulkReply();
+        }
+    }
+
+    @Override
+    public List<byte[]> getBinaryMultiBulkReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                /*
+                  Checking if serializer is already set if not that means request sent bytes data i.e. before reaching
+                  redis client serialization is done. As JDK_REDIS_SERIALIZATION is the most used serializer using this
+                  serializer.
+                 */
+                if (Objects.equals(meta.get("serializer"), SerializationType.REDIS_SERIALIZATION.toString())) {
+                    return super.getBinaryMultiBulkReply();
+                } else {
+                    // recording data
+                    List<byte[]> binaryMultiBulkReply = super.getBinaryMultiBulkReply();
+                    List<Object> response = new ArrayList<>();
+                    for(byte[] i:binaryMultiBulkReply) {
+                        Object deserializedObject = jdkSerializationRedisSerializer.deserialize(i);
+                        response.add(deserializedObject);
+                    }
+                    meta.put("response", gson.toJson(response));
+                    sendToServer();
+                    return binaryMultiBulkReply;
+                }
+            case MODE_TEST:
+                // sending recorded data
+                List<byte[]> response = new ArrayList<>();
+                Type listOfObject = new TypeToken<List<Object>>() {}.getType();
+                List<Object> lObj = gson.fromJson(meta.get("response"), listOfObject);
+                for (Object i: lObj) {
+                    response.add(jdkSerializationRedisSerializer.serialize(i));
+                }
+                return response;
+            default:
+                return super.getBinaryMultiBulkReply();
+        }
+    }
+
+    @Override
+    public void resetPipelinedCount() {
+        super.resetPipelinedCount();
+    }
+
+    @Override
+    public List<Object> getRawObjectMultiBulkReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                List<Object> rawObjectMultiBulkReply = super.getRawObjectMultiBulkReply();
+                meta.put("response", gson.toJson(rawObjectMultiBulkReply));
+                sendToServer();
+                return rawObjectMultiBulkReply;
+            case MODE_TEST:
+                // sending recorded data
+                Type listOfObject = new TypeToken<List<Object>>() {}.getType();
+                return gson.fromJson(meta.get("response"),listOfObject);
+            default:
+                return super.getRawObjectMultiBulkReply();
+        }
+    }
+
+    @Override
+    public List<Object> getObjectMultiBulkReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                List<Object> objectMultiBulkReply = super.getObjectMultiBulkReply();
+                meta.put("response", gson.toJson(objectMultiBulkReply));
+                sendToServer();
+                return objectMultiBulkReply;
+            case MODE_TEST:
+                // sending recorded data
+                Type listOfObject = new TypeToken<List<Object>>() {}.getType();
+                return gson.fromJson(meta.get("response"),listOfObject);
+            default:
+                return super.getObjectMultiBulkReply();
+        }
+    }
+
+    @Override
+    public List<Long> getIntegerMultiBulkReply() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                List<Long> integerMultiBulkReply = super.getIntegerMultiBulkReply();
+                meta.put("response", gson.toJson(integerMultiBulkReply));
+                sendToServer();
+                return integerMultiBulkReply;
+            case MODE_TEST:
+                // sending recorded data
+                Type listOfLong = new TypeToken<List<Long>>() {}.getType();
+                return gson.fromJson(meta.get("response"),listOfLong);
+            default:
+                return super.getIntegerMultiBulkReply();
+        }
+    }
+
+    @Override
+    public List<Object> getAll() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                List<Object> getAll = super.getAll();
+                meta.put("response", gson.toJson(getAll));
+                sendToServer();
+                return getAll;
+            case MODE_TEST:
+                // sending recorded data
+                Type listOfObject = new TypeToken<List<Object>>() {}.getType();
+                return gson.fromJson(meta.get("response"),listOfObject);
+            default:
+                return super.getAll();
+        }
+    }
+
+    @Override
+    public List<Object> getAll(int except) {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                List<Object> getAll = super.getAll(except);
+                meta.put("response", gson.toJson(getAll));
+                sendToServer();
+                return getAll;
+            case MODE_TEST:
+                // sending recorded data
+                Type listOfObject = new TypeToken<List<Object>>() {}.getType();
+                return gson.fromJson(meta.get("response"),listOfObject);
+            default:
+                return super.getAll(except);
+        }
+    }
+
+    @Override
+    public Object getOne() {
+        switch (keployMode) {
+            case MODE_RECORD:
+                // recording data
+                Object getOne = super.getOne();
+                meta.put("response", gson.toJson(getOne));
+                sendToServer();
+                return getOne;
+            case MODE_TEST:
+                // sending recorded data
+                return gson.fromJson(meta.get("response"),Object.class);
+            default:
+                return super.getOne();
+        }
+    }
+
+    @Override
+    public boolean isBroken() {
+        return super.isBroken();
+    }
+
+    @Override
+    protected void flush() {
+        super.flush();
+    }
+
+    @Override
+    protected Object readProtocolWithCheckingBroken() {
+        return super.readProtocolWithCheckingBroken();
+    }
+
+    // method to send data to server
+    private void sendToServer() {
+        Kcontext kctx = Context.getCtx();
+        logger.info(meta.toString());
+        if (Objects.equals(meta.get("command"),Protocol.Command.PING.toString()) ||
+                Objects.equals(meta.get("command"),Protocol.Command.QUIT.toString())) {
+            return;
+        }
+        Service.Mock.SpecSchema specSchema = Service.Mock.SpecSchema.newBuilder()
+                .putAllMetadata(meta)
+                .build();
+        Service.Mock redisMock = Service.Mock.newBuilder()
+                .setVersion(Mock.Version.V1_BETA1.value)
+                .setKind(Mock.Kind.GENERIC_EXPORT.value)
+                .setSpec(specSchema)
+                .build();
+        kctx.getMock().add(redisMock);
+    }
+
+    // method to fill meta with the mock
+    private void fillMock() {
+        Kcontext kctx = Context.getCtx();
+        if ( kctx.getMock().size() > 0 && kctx.getMock().get(0).getKind().equals(Mock.Kind.GENERIC_EXPORT.value)) {
+            List<Service.Mock> mocks = kctx.getMock();
+            meta = mocks.get(0).getSpec().getMetadataMap();
+                mocks.remove(0);
+        } else {
+            logger.error(CROSS + " mocks not present in " + KeployInstance.getInstance().getKeploy().getCfg().getApp().getMockPath() + " directory.");
+            throw new RuntimeException("unable to read mocks from keploy context");
+        }
+    }
+
+    public enum SerializationType {
+        REDIS_SERIALIZATION,
+        JDK_REDIS_SERIALIZATION;
+
+        SerializationType() {
+
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: charankamarapu <kamarapucharan@gmail.com>

Problem: Java SDK does not support Redis.
Solution: Added Redis(Jedis) support for Java SDK
Testing: Tested against a sample project [Redis Project](https://github.com/chandra-goka/SpringBoot-Redis-Example)
Did you use Java Docs ? Yes, I have used java doc for comments