### PR TITLE
Feature/356/add checkstyle GitHub action to Java-SDK pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,8 +32,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dbelyaev/action-checkstyle@v0.6.1
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           checkstyle_config: checkstyle-config.xml
           fail_on_error: true
+
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: JavaSDK build check 
+name: JavaSDK build check
 
 on:
   push:
@@ -15,12 +15,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+  checkstyle:
+    name: checkstyle linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dbelyaev/action-checkstyle@v0.6.1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          checkstyle_config: checkstyle-config.xml
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,4 +35,5 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           checkstyle_config: checkstyle-config.xml
+          fail_on_error: true
 

--- a/checkstyle-config.xml
+++ b/checkstyle-config.xml
@@ -35,9 +35,4 @@
     <!--        <property name="fileNamePattern" value="/agent/"/>-->
     <!--    </module>-->
 
-    <module name="FileLength"/>
-    <module name="LineLength">
-        <property name="fileExtensions" value="java"/>
-    </module>
-
 </module>

--- a/checkstyle-config.xml
+++ b/checkstyle-config.xml
@@ -1,186 +1,182 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
-    <property name="severity" value="error"/>
+  <property name="severity" value="error"/>
 
-    <property name="fileExtensions" value="java, properties, xml"/>
+  <property name="fileExtensions" value="java, properties, xml"/>
+
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="/models/"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="/core/"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="/common/"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="/integration/"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="/agent/"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="/keploy-sdk/"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="/api/"/>
+  </module>
 
 
-    <!--    This for ignoring specific module when start applying rules so cleaning rules violations would be easier and organized    -->
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/models/"/>
-        </module>
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/core/"/>
-        </module>
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/common/"/>
-        </module>
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/integration/"/>
-        </module>
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/Agent/"/>
-        </module>
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/keploy-sdk/"/>
-        </module>
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/api/"/>
-        </module>
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="/agent/"/>
-        </module>
-    
-    
-	  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
-	  <module name="SuppressionFilter">
-	    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
-		      default="checkstyle-suppressions.xml" />
-	    <property name="optional" value="true"/>
-	  </module>
+  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+              default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
 
-	  <!-- Checks that a package-info.java file exists for each package.     -->
-	  <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
-	  <module name="JavadocPackage"/>
+  <!-- Checks that a package-info.java file exists for each package.     -->
+  <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+  <module name="JavadocPackage"/>
 
-	  <!-- Checks whether files end with a new line.                        -->
-	  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
-	  <module name="NewlineAtEndOfFile"/>
+  <!-- Checks whether files end with a new line.                        -->
+  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+  <module name="NewlineAtEndOfFile"/>
 
-	  <!-- Checks that property files contain the same keys.         -->
-	  <!-- See https://checkstyle.org/config_misc.html#Translation -->
-	  <module name="Translation"/>
+  <!-- Checks that property files contain the same keys.         -->
+  <!-- See https://checkstyle.org/config_misc.html#Translation -->
+  <module name="Translation"/>
 
-	  <!-- Checks for Size Violations.                    -->
-	  <!-- See https://checkstyle.org/config_sizes.html -->
-	  <module name="FileLength"/>
-	  <module name="LineLength">
-	    <property name="fileExtensions" value="java"/>
-	  </module>
+  <!-- Checks for Size Violations.                    -->
+  <!-- See https://checkstyle.org/config_sizes.html -->
+  <module name="FileLength"/>
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+  </module>
 
-	  <!-- Checks for whitespace                               -->
-	  <!-- See https://checkstyle.org/config_whitespace.html -->
-	  <module name="FileTabCharacter"/>
+  <!-- Checks for whitespace                               -->
+  <!-- See https://checkstyle.org/config_whitespace.html -->
+  <module name="FileTabCharacter"/>
 
-	  <!-- Miscellaneous other checks.                   -->
-	  <!-- See https://checkstyle.org/config_misc.html -->
-	  <module name="RegexpSingleline">
-	    <property name="format" value="\s+$"/>
-	    <property name="minimum" value="0"/>
-	    <property name="maximum" value="0"/>
-	    <property name="message" value="Line has trailing spaces."/>
-	  </module>
+  <!-- Miscellaneous other checks.                   -->
+  <!-- See https://checkstyle.org/config_misc.html -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
 
-	  <!-- Checks for Headers                                -->
-	  <!-- See https://checkstyle.org/config_header.html   -->
-	  <!-- <module name="Header"> -->
-	  <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
-	  <!--   <property name="fileExtensions" value="java"/> -->
-	  <!-- </module> -->
+  <!-- Checks for Headers                                -->
+  <!-- See https://checkstyle.org/config_header.html   -->
+  <!-- <module name="Header"> -->
+  <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+  <!--   <property name="fileExtensions" value="java"/> -->
+  <!-- </module> -->
 
-	  <module name="TreeWalker">
+  <module name="TreeWalker">
 
-	    <!-- Checks for Javadoc comments.                     -->
-	    <!-- See https://checkstyle.org/config_javadoc.html -->
-	    <module name="InvalidJavadocPosition"/>
-	    <module name="JavadocMethod"/>
-	    <module name="JavadocType"/>
-	    <module name="JavadocVariable"/>
-	    <module name="JavadocStyle"/>
-	    <module name="MissingJavadocMethod"/>
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See https://checkstyle.org/config_javadoc.html -->
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocMethod"/>
+    <module name="JavadocType"/>
+    <module name="JavadocVariable"/>
+    <module name="JavadocStyle"/>
+    <module name="MissingJavadocMethod"/>
 
-	    <!-- Checks for Naming Conventions.                  -->
-	    <!-- See https://checkstyle.org/config_naming.html -->
-	    <module name="ConstantName"/>
-	    <module name="LocalFinalVariableName"/>
-	    <module name="LocalVariableName"/>
-	    <module name="MemberName"/>
-	    <module name="MethodName"/>
-	    <module name="PackageName"/>
-	    <module name="ParameterName"/>
-	    <module name="StaticVariableName"/>
-	    <module name="TypeName"/>
+    <!-- Checks for Naming Conventions.                  -->
+    <!-- See https://checkstyle.org/config_naming.html -->
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName"/>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
 
-	    <!-- Checks for imports                              -->
-	    <!-- See https://checkstyle.org/config_imports.html -->
-	    <module name="AvoidStarImport"/>
-	    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
-	    <module name="RedundantImport"/>
-	    <module name="UnusedImports">
-	      <property name="processJavadoc" value="false"/>
-	    </module>
+    <!-- Checks for imports                              -->
+    <!-- See https://checkstyle.org/config_imports.html -->
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="processJavadoc" value="false"/>
+    </module>
 
-	    <!-- Checks for Size Violations.                    -->
-	    <!-- See https://checkstyle.org/config_sizes.html -->
-	    <module name="MethodLength"/>
-	    <module name="ParameterNumber"/>
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+    <module name="MethodLength"/>
+    <module name="ParameterNumber"/>
 
-	    <!-- Checks for whitespace                               -->
-	    <!-- See https://checkstyle.org/config_whitespace.html -->
-	    <module name="EmptyForIteratorPad"/>
-	    <module name="GenericWhitespace"/>
-	    <module name="MethodParamPad"/>
-	    <module name="NoWhitespaceAfter"/>
-	    <module name="NoWhitespaceBefore"/>
-	    <module name="OperatorWrap"/>
-	    <module name="ParenPad"/>
-	    <module name="TypecastParenPad"/>
-	    <module name="WhitespaceAfter"/>
-	    <module name="WhitespaceAround"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+    <module name="EmptyForIteratorPad"/>
+    <module name="GenericWhitespace"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
 
-	    <!-- Modifier Checks                                    -->
-	    <!-- See https://checkstyle.org/config_modifier.html -->
-	    <module name="ModifierOrder"/>
-	    <module name="RedundantModifier"/>
+    <!-- Modifier Checks                                    -->
+    <!-- See https://checkstyle.org/config_modifier.html -->
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
 
-	    <!-- Checks for blocks. You know, those {}'s         -->
-	    <!-- See https://checkstyle.org/config_blocks.html -->
-	    <module name="AvoidNestedBlocks"/>
-	    <module name="EmptyBlock"/>
-	    <module name="LeftCurly"/>
-	    <module name="NeedBraces"/>
-	    <module name="RightCurly"/>
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See https://checkstyle.org/config_blocks.html -->
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock"/>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
 
-	    <!-- Checks for common coding problems               -->
-	    <!-- See https://checkstyle.org/config_coding.html -->
-	    <module name="EmptyStatement"/>
-	    <module name="EqualsHashCode"/>
-	    <module name="HiddenField"/>
-	    <module name="IllegalInstantiation"/>
-	    <module name="InnerAssignment"/>
-	    <module name="MagicNumber"/>
-	    <module name="MissingSwitchDefault"/>
-	    <module name="MultipleVariableDeclarations"/>
-	    <module name="SimplifyBooleanExpression"/>
-	    <module name="SimplifyBooleanReturn"/>
+    <!-- Checks for common coding problems               -->
+    <!-- See https://checkstyle.org/config_coding.html -->
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="HiddenField"/>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <module name="MagicNumber"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
 
-	    <!-- Checks for class design                         -->
-	    <!-- See https://checkstyle.org/config_design.html -->
-	    <module name="DesignForExtension"/>
-	    <module name="FinalClass"/>
-	    <module name="HideUtilityClassConstructor"/>
-	    <module name="InterfaceIsType"/>
-	    <module name="VisibilityModifier"/>
+    <!-- Checks for class design                         -->
+    <!-- See https://checkstyle.org/config_design.html -->
+    <module name="DesignForExtension"/>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier"/>
 
-	    <!-- Miscellaneous other checks.                   -->
-	    <!-- See https://checkstyle.org/config_misc.html -->
-	    <module name="ArrayTypeStyle"/>
-	    <module name="FinalParameters"/>
-	    <module name="TodoComment"/>
-	    <module name="UpperEll"/>
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+    <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters"/>
+    <module name="TodoComment"/>
+    <module name="UpperEll"/>
 
-	    <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
-	    <module name="SuppressionXpathFilter">
-	      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
-		        default="checkstyle-xpath-suppressions.xml" />
-	      <property name="optional" value="true"/>
-	    </module>
+    <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
 
-	  </module>
-        
+  </module>
 
 </module>

--- a/checkstyle-config.xml
+++ b/checkstyle-config.xml
@@ -35,4 +35,9 @@
     <!--        <property name="fileNamePattern" value="/agent/"/>-->
     <!--    </module>-->
 
+    <module name="FileLength"/>
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+    </module>
+
 </module>

--- a/checkstyle-config.xml
+++ b/checkstyle-config.xml
@@ -10,29 +10,177 @@
 
 
     <!--    This for ignoring specific module when start applying rules so cleaning rules violations would be easier and organized    -->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/models/"/>-->
-    <!--    </module>-->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/core/"/>-->
-    <!--    </module>-->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/common/"/>-->
-    <!--    </module>-->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/integration/"/>-->
-    <!--    </module>-->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/Agent/"/>-->
-    <!--    </module>-->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/keploy-sdk/"/>-->
-    <!--    </module>-->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/api/"/>-->
-    <!--    </module>-->
-    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
-    <!--        <property name="fileNamePattern" value="/agent/"/>-->
-    <!--    </module>-->
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/models/"/>
+        </module>
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/core/"/>
+        </module>
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/common/"/>
+        </module>
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/integration/"/>
+        </module>
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/Agent/"/>
+        </module>
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/keploy-sdk/"/>
+        </module>
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/api/"/>
+        </module>
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="/agent/"/>
+        </module>
+    
+    
+	  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+	  <module name="SuppressionFilter">
+	    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+		      default="checkstyle-suppressions.xml" />
+	    <property name="optional" value="true"/>
+	  </module>
+
+	  <!-- Checks that a package-info.java file exists for each package.     -->
+	  <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+	  <module name="JavadocPackage"/>
+
+	  <!-- Checks whether files end with a new line.                        -->
+	  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+	  <module name="NewlineAtEndOfFile"/>
+
+	  <!-- Checks that property files contain the same keys.         -->
+	  <!-- See https://checkstyle.org/config_misc.html#Translation -->
+	  <module name="Translation"/>
+
+	  <!-- Checks for Size Violations.                    -->
+	  <!-- See https://checkstyle.org/config_sizes.html -->
+	  <module name="FileLength"/>
+	  <module name="LineLength">
+	    <property name="fileExtensions" value="java"/>
+	  </module>
+
+	  <!-- Checks for whitespace                               -->
+	  <!-- See https://checkstyle.org/config_whitespace.html -->
+	  <module name="FileTabCharacter"/>
+
+	  <!-- Miscellaneous other checks.                   -->
+	  <!-- See https://checkstyle.org/config_misc.html -->
+	  <module name="RegexpSingleline">
+	    <property name="format" value="\s+$"/>
+	    <property name="minimum" value="0"/>
+	    <property name="maximum" value="0"/>
+	    <property name="message" value="Line has trailing spaces."/>
+	  </module>
+
+	  <!-- Checks for Headers                                -->
+	  <!-- See https://checkstyle.org/config_header.html   -->
+	  <!-- <module name="Header"> -->
+	  <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+	  <!--   <property name="fileExtensions" value="java"/> -->
+	  <!-- </module> -->
+
+	  <module name="TreeWalker">
+
+	    <!-- Checks for Javadoc comments.                     -->
+	    <!-- See https://checkstyle.org/config_javadoc.html -->
+	    <module name="InvalidJavadocPosition"/>
+	    <module name="JavadocMethod"/>
+	    <module name="JavadocType"/>
+	    <module name="JavadocVariable"/>
+	    <module name="JavadocStyle"/>
+	    <module name="MissingJavadocMethod"/>
+
+	    <!-- Checks for Naming Conventions.                  -->
+	    <!-- See https://checkstyle.org/config_naming.html -->
+	    <module name="ConstantName"/>
+	    <module name="LocalFinalVariableName"/>
+	    <module name="LocalVariableName"/>
+	    <module name="MemberName"/>
+	    <module name="MethodName"/>
+	    <module name="PackageName"/>
+	    <module name="ParameterName"/>
+	    <module name="StaticVariableName"/>
+	    <module name="TypeName"/>
+
+	    <!-- Checks for imports                              -->
+	    <!-- See https://checkstyle.org/config_imports.html -->
+	    <module name="AvoidStarImport"/>
+	    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+	    <module name="RedundantImport"/>
+	    <module name="UnusedImports">
+	      <property name="processJavadoc" value="false"/>
+	    </module>
+
+	    <!-- Checks for Size Violations.                    -->
+	    <!-- See https://checkstyle.org/config_sizes.html -->
+	    <module name="MethodLength"/>
+	    <module name="ParameterNumber"/>
+
+	    <!-- Checks for whitespace                               -->
+	    <!-- See https://checkstyle.org/config_whitespace.html -->
+	    <module name="EmptyForIteratorPad"/>
+	    <module name="GenericWhitespace"/>
+	    <module name="MethodParamPad"/>
+	    <module name="NoWhitespaceAfter"/>
+	    <module name="NoWhitespaceBefore"/>
+	    <module name="OperatorWrap"/>
+	    <module name="ParenPad"/>
+	    <module name="TypecastParenPad"/>
+	    <module name="WhitespaceAfter"/>
+	    <module name="WhitespaceAround"/>
+
+	    <!-- Modifier Checks                                    -->
+	    <!-- See https://checkstyle.org/config_modifier.html -->
+	    <module name="ModifierOrder"/>
+	    <module name="RedundantModifier"/>
+
+	    <!-- Checks for blocks. You know, those {}'s         -->
+	    <!-- See https://checkstyle.org/config_blocks.html -->
+	    <module name="AvoidNestedBlocks"/>
+	    <module name="EmptyBlock"/>
+	    <module name="LeftCurly"/>
+	    <module name="NeedBraces"/>
+	    <module name="RightCurly"/>
+
+	    <!-- Checks for common coding problems               -->
+	    <!-- See https://checkstyle.org/config_coding.html -->
+	    <module name="EmptyStatement"/>
+	    <module name="EqualsHashCode"/>
+	    <module name="HiddenField"/>
+	    <module name="IllegalInstantiation"/>
+	    <module name="InnerAssignment"/>
+	    <module name="MagicNumber"/>
+	    <module name="MissingSwitchDefault"/>
+	    <module name="MultipleVariableDeclarations"/>
+	    <module name="SimplifyBooleanExpression"/>
+	    <module name="SimplifyBooleanReturn"/>
+
+	    <!-- Checks for class design                         -->
+	    <!-- See https://checkstyle.org/config_design.html -->
+	    <module name="DesignForExtension"/>
+	    <module name="FinalClass"/>
+	    <module name="HideUtilityClassConstructor"/>
+	    <module name="InterfaceIsType"/>
+	    <module name="VisibilityModifier"/>
+
+	    <!-- Miscellaneous other checks.                   -->
+	    <!-- See https://checkstyle.org/config_misc.html -->
+	    <module name="ArrayTypeStyle"/>
+	    <module name="FinalParameters"/>
+	    <module name="TodoComment"/>
+	    <module name="UpperEll"/>
+
+	    <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+	    <module name="SuppressionXpathFilter">
+	      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+		        default="checkstyle-xpath-suppressions.xml" />
+	      <property name="optional" value="true"/>
+	    </module>
+
+	  </module>
+        
 
 </module>

--- a/checkstyle-config.xml
+++ b/checkstyle-config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+
+    <!--    This for ignoring specific module when start applying rules so cleaning rules violations would be easier and organized    -->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/models/"/>-->
+    <!--    </module>-->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/core/"/>-->
+    <!--    </module>-->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/common/"/>-->
+    <!--    </module>-->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/integration/"/>-->
+    <!--    </module>-->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/Agent/"/>-->
+    <!--    </module>-->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/keploy-sdk/"/>-->
+    <!--    </module>-->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/api/"/>-->
+    <!--    </module>-->
+    <!--    <module name="BeforeExecutionExclusionFileFilter">-->
+    <!--        <property name="fileNamePattern" value="/agent/"/>-->
+    <!--    </module>-->
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,25 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.puppycrawl.tools</groupId>
+                                <artifactId>checkstyle</artifactId>
+                                <version>8.31</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.keploy</groupId>
+                                <artifactId>java-sdk</artifactId>
+                                <version>1.0.0-SNAPSHOT</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <configLocation>checkstyle-config.xml</configLocation>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>3.2.1</version>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -189,6 +189,20 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.31</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>checkstyle-config.xml</configLocation>
+                </configuration>
+            </plugin>
             <!--                        <plugin>-->
             <!--                            <groupId>org.apache.maven.plugins</groupId>-->
             <!--                            <artifactId>maven-gpg-plugin</artifactId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -68,25 +68,6 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                        <dependencies>
-                            <dependency>
-                                <groupId>com.puppycrawl.tools</groupId>
-                                <artifactId>checkstyle</artifactId>
-                                <version>8.31</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>io.keploy</groupId>
-                                <artifactId>java-sdk</artifactId>
-                                <version>1.0.0-SNAPSHOT</version>
-                            </dependency>
-                        </dependencies>
-                        <configuration>
-                            <configLocation>checkstyle-config.xml</configLocation>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>3.2.1</version>
                         <executions>


### PR DESCRIPTION
## Related Issue
- This issue is to setup a proper java based linter that enforce the conventional java coding standards and add an action for code style check to the pipeline.
I chose checkstyle as it's most popular tool for checking java code and it's very easy and usable to be configured

Closes: [#356](https://github.com/keploy/keploy/issues/356)


#### Describe the changes you've made
I added a the checkstyle plugin in `pom.xml` and configured it to use a specific configuration file I added so we can add and configure a proper set of rules (or we can use a common configuration file such as sun_check.xml).
I added an action in the pipeline as well to check the code using the configuration file added by me too so the same rules check applied both on the pipeline action or locally.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How did you test your code changes?
I tried those changes on a forked repo and tried to make a PR with the empty configuration file to check it should pass **as there are no rules to check** then added a rule that should fail the pipeline and pushed it and checked that the pipeline did fail.
when tried to apply rules on agent module this is what I got:
![image](https://user-images.githubusercontent.com/58189568/223718044-a6c9585b-4977-48ea-bbe3-d41bb175ac4c.png)
and pipeline failed
![image](https://user-images.githubusercontent.com/58189568/223718127-cd286818-4939-430d-b91f-12c1cce2319d.png)
