### PR TITLE
@Advice.Origin annotation is not being used.

### DIFF
--- a/agent/src/main/java/io/keploy/advice/ksql/RegisterDriverAdvice.java
+++ b/agent/src/main/java/io/keploy/advice/ksql/RegisterDriverAdvice.java
@@ -1,8 +1,8 @@
 package io.keploy.advice.ksql;
 
 import io.keploy.ksql.KDriver;
-import net.bytebuddy.asm.Advice;
 
+import net.bytebuddy.asm.Advice;
 import java.lang.reflect.Method;
 
 /**
@@ -14,12 +14,11 @@ public class RegisterDriverAdvice {
     /**
      * This method gets executed before the setDriverClassName method of DataSourceProperties class. According to the
      * driverClassName that is present, Dialect of KDriver is changed and driverClassName value is replaced with KDriver
-     * path
+     * path.
      */
     @Advice.OnMethodEnter
     public static void enterMethod(@Advice.Origin Method method, @Advice.Argument(value = 0, readOnly = false) String driverClassName) {
-
-        if (driverClassName != null && !driverClassName.equals("io.keploy.ksql.KDriver")) {
+        if (driverClassName != null && !driverClassName.equals(KDriver.class.getName())) {
             KDriver.DriverName = driverClassName;
             switch (driverClassName) {
                 case "org.postgresql.Driver":
@@ -37,16 +36,19 @@ public class RegisterDriverAdvice {
                     break;
                 default:
                     System.out.println("Dialect for driver: " + driverClassName + " is not supported yet");
+                    driverClassName = KDriver.class.getName();
+                    break;
             }
+        } else {
+            driverClassName = KDriver.class.getName();
         }
-        driverClassName = "io.keploy.ksql.KDriver";
     }
 
     /**
-     * This method gets executed after the setDriverClassName method of DataSourceProperties class.This does nothing as we don't
+     * This method gets executed after the setDriverClassName method of DataSourceProperties class. This does nothing as we don't
      * want to change anything after the completion of the setDriverClassName method of DataSourceProperties class.
      */
     @Advice.OnMethodExit
-    public static void exitMethod(@Advice.Origin Method method) {
+    public static void exitMethod() {
     }
 }


### PR DESCRIPTION
we can remove this i.e:
1.if its not being used, exitMethod to remove the @Advice.Origin annotation since it's not being used. 2.Replaced the hardcoded io.keploy.ksql.KDriver with KDriver.class.getName() to avoid potential bugs if the class name changes. 3.Added a check for if the driverClassName argument is already equal to KDriver.class.getName() to avoid unnecessary re-assignment.

## Related Issue
- Info about Issue or bug

Closes: #[issue number that will be closed through this PR]

#### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How did you test your code changes?


the changes made to the code are:

Removed the unnecessary import of net.bytebuddy.asm.Advice since it's already being imported by the class.
Replaced the hardcoded io.keploy.ksql.KDriver with KDriver.class.getName() to avoid potential bugs if the class name changes.
Added a check for if the driverClassName argument is already equal to KDriver.class.getName() to avoid unnecessary re-assignment.
Added a break statement in the default case of the switch statement to prevent unnecessary execution of subsequent cases.
Updated the exitMethod to remove the @Advice.Origin annotation since it's not being used.












Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas and used java doc.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |