### PR TITLE
fix: keploy fails to stop when tests end

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,12 @@
             <artifactId>progressbar</artifactId>
             <version>0.9.5</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.9.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Related Issue
- Keploy fails to stop when tests end. This happens in the case of Junit integration with keploy.

Closes: https://github.com/keploy/keploy/issues/864

#### Describe the changes you've made
- Added a function to not just kill the parent but child processes sharing the same running port.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas and used java doc.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |