### PR TITLE
fix: calls stopTest to unload the ebpf hooks after running test-sets

### DIFF
--- a/v2/src/main/java/io/keploy/Keploy.java
+++ b/v2/src/main/java/io/keploy/Keploy.java
@@ -476,9 +476,10 @@ public class Keploy {
                 e.printStackTrace();
             }
             stopUserApplication();
-            // unload the ebpf hooks from the kernel
-            StopTest();
         }
+        logger.debug("All test sets executed and stoping the ebpf hooks" );
+        // unload the ebpf hooks from the kernel
+        StopTest();
     }
 
     private static void startUserApplication(String jarPath) {


### PR DESCRIPTION
## Related Issue
- unit test fails for application with multiple test-sets

Closes: #

#### Describe the changes you've made
Calls the stopTest after running all the test-set for an application.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How did you test your code changes?

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas and used java doc.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
