### PR TITLE
feat: add closeDelay to support async calls coverage

### DIFF
--- a/v2/src/main/java/io/keploy/Keploy.java
+++ b/v2/src/main/java/io/keploy/Keploy.java
@@ -30,12 +30,13 @@ public class Keploy {
         private int port;
         private String path;
         private String appCmd;
+        private int closeDelay;
 
         public RunOptions() {
-            this(10, false, 6789, ".");
+            this(10, false, 6789, ".",0);
         }
 
-        public RunOptions(int delay, boolean debug, int port, String path) {
+        public RunOptions(int delay, boolean debug, int port, String path,int closeDelay) {
             if (delay < 0) {
                 throw new IllegalArgumentException("Delay must be a positive integer.");
             }
@@ -52,6 +53,11 @@ public class Keploy {
                 throw new IllegalArgumentException("Port must be a positive integer.");
             }
             this.port = port;
+
+            if (closeDelay < 0) {
+                throw new IllegalArgumentException("CloseDelay must be a positive integer.");
+            }
+            this.closeDelay = closeDelay;
         }
 
         // Getters and setters
@@ -64,6 +70,17 @@ public class Keploy {
                 throw new IllegalArgumentException("Delay must be a positive integer.");
             }
             this.delay = delay;
+        }
+
+        public int getCloseDelay() {
+            return closeDelay;
+        }
+
+        public void setCloseDelay(int closeDelay) {
+            if (closeDelay < 0) {
+                throw new IllegalArgumentException("CloseDelay must be a positive integer.");
+            }
+            this.closeDelay = closeDelay;
         }
 
         public boolean isDebug() {
@@ -539,6 +556,12 @@ public class Keploy {
                 waitForTestRunCompletion(testRunId, testSet, appId);
 
                 try {
+                    if (runOptions.getCloseDelay() > 0){
+                        logger.info("waiting for {} seconds before closing the application in order to get coverage of async calls", runOptions.getCloseDelay());
+                        //wait for closeDelay in order to get coverage of async calls as well
+                        Thread.sleep(runOptions.getCloseDelay() * 1000);
+                    }
+                    
                     Keploy.FindCoverage(testSet);
 
                     Thread.sleep(5000);
@@ -546,7 +569,7 @@ public class Keploy {
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-
+                System.out.println("sleeping for 7 more seconds to get async call coverages");
                 String appErr = stopUserApplication(appId);
 
                 if (appErr != null) {

--- a/v2/src/main/java/io/keploy/Keploy.java
+++ b/v2/src/main/java/io/keploy/Keploy.java
@@ -33,7 +33,7 @@ public class Keploy {
         private int closeDelay;
 
         public RunOptions() {
-            this(10, false, 6789, ".",0);
+            this(10, false, 6789, ".", 0);
         }
 
         public RunOptions(int delay, boolean debug, int port, String path,int closeDelay) {
@@ -569,7 +569,7 @@ public class Keploy {
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-                System.out.println("sleeping for 7 more seconds to get async call coverages");
+
                 String appErr = stopUserApplication(appId);
 
                 if (appErr != null) {


### PR DESCRIPTION
## Related Issue
- We need to support async calls so that coverage of these calls can also be covered during keploy test run via mvn test.

Closes: https://github.com/keploy/keploy/issues/1836

#### Describe the changes you've made
- Added a `closeDelay` which is by default 0 but can be configured according to the latency of the async call.
- This delay is helpful when your application is making an async call because we don't wait for anything after the test run is completed. This flow was ignoring the async call and related coverage was not getting added.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How did you test your code changes?

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas and used java doc.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |