### PR TITLE
fix: update sdk to add testSet to dedupData as well

### DIFF
--- a/integration/src/main/java/io/keploy/servlet/KeployMiddleware.java
+++ b/integration/src/main/java/io/keploy/servlet/KeployMiddleware.java
@@ -77,6 +77,7 @@ public class KeployMiddleware implements Filter {
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
         String keploy_test_id = request.getHeader("KEPLOY-TEST-ID");
+        String keploy_test_set_id = request.getHeader("KEPLOY-TEST-SET-ID");
         // logger.debug("KEPLOY-TEST-ID: {}", keploy_test_id);
         filterChain.doFilter(request, response);
         if (System.getenv("ENABLE_DEDUP") != null) {
@@ -89,7 +90,7 @@ public class KeployMiddleware implements Filter {
             // Run getCoverage in a separate thread
 //            Thread coverageThread = new Thread(() -> {
             try {
-                getCoverage(keploy_test_id);
+                getCoverage(keploy_test_id, keploy_test_set_id);
             } catch (InterruptedException | IOException e) {
                 throw new RuntimeException(e);
             }
@@ -180,7 +181,7 @@ public class KeployMiddleware implements Filter {
         }
     }
 
-    public void getCoverage(String keploy_test_id) throws IOException, InterruptedException {
+    public void getCoverage(String keploy_test_id, String keploy_test_set_id) throws IOException, InterruptedException {
 
         try {
             execWriter(keploy_test_id);
@@ -189,7 +190,7 @@ public class KeployMiddleware implements Filter {
         }
 
         try {
-            execReader(keploy_test_id);
+            execReader(keploy_test_id, keploy_test_set_id);
         } catch (IOException e) {
             e.printStackTrace(); // Example: print the stack trace
         }
@@ -200,7 +201,7 @@ public class KeployMiddleware implements Filter {
         executorService.shutdown();
     }
 
-    private void execReader(String keploy_test_id) throws IOException {
+    private void execReader(String keploy_test_id, String keploy_test_set_id) throws IOException {
         // Together with the original class definition we can calculate coverage
         // information:
         out.println("------------------------------------------");
@@ -249,7 +250,7 @@ public class KeployMiddleware implements Filter {
 //        System.out.println("Line_Path: " + Line_Path);
 
         Map<String, Object> testData = new HashMap<>();
-        testData.put("id", keploy_test_id);
+        testData.put("id", keploy_test_set_id+ "/" + keploy_test_id);
         // Map<String, Object> test1 = createTestData("test-1",testData);
         testData.put("executedLinesByFile", executedLinesByFile);
 

--- a/keploy-sdk/pom.xml
+++ b/keploy-sdk/pom.xml
@@ -149,26 +149,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.5.0</version>

--- a/keploy-sdk/pom.xml
+++ b/keploy-sdk/pom.xml
@@ -149,6 +149,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
+                    <!-- <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.5</version>
@@ -107,7 +107,7 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
+                    </plugin> -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
## Related Issue
Currently the sdk only gives the test data in the dedupdata.yaml file which makes it unable to run dedup for multiple testsets.

[Closes](https://github.com/keploy/enterprise/issues/322)

#### Describe the changes you've made
Added test set information to the sdk.

## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How did you test your code changes?

Please describe the tests(if any). Provide instructions how its affecting the coverage.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
A clear and concise description of it.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas and used java doc.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if any)

|        Original         |          Updated           |
|:-----------------------:|:--------------------------:|
| **original screenshot** | <b>updated screenshot </b> |