### PR TITLE
fix: align Java SDK release tag trigger

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -1,6 +1,6 @@
 when:
   - event: tag
-    ref: refs/tags/v*
+    ref: refs/tags/v*.*.*
 
 labels:
   platform: linux/amd64
@@ -10,7 +10,7 @@ clone:
     image: woodpeckerci/plugin-git
     settings:
       lfs: false
-      depth: 1
+      depth: 0
 
 steps:
   release:


### PR DESCRIPTION
## Summary
- Align the Java SDK Woodpecker release tag filter with the enterprise release pipeline (`refs/tags/v*.*.*`).
- Use a full-depth clone for release jobs, matching enterprise release behavior.

## Why
The `v2.0.0` tag did not trigger the Java SDK release pipeline as expected. Enterprise release jobs use the stricter semver-style tag ref, so this brings Java SDK onto the same release trigger pattern.

## Validation
- `git diff --check`
- `mvn -B -DskipTests clean verify`
