### PR TITLE
feat: run Java dedup as java agent

### DIFF
--- a/.github/workflows/java-agent.yml
+++ b/.github/workflows/java-agent.yml
@@ -1,0 +1,33 @@
+name: Java Agent
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    name: JDK ${{ matrix.java-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ["8", "17", "21"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: maven
+
+      - name: Build
+        run: mvn -B -DskipTests clean verify
+
+      - name: Smoke test Java agent
+        run: ./scripts/smoke-javaagent.sh

--- a/.woodpecker/build.yml
+++ b/.woodpecker/build.yml
@@ -18,13 +18,16 @@ steps:
     image: maven:3.9-eclipse-temurin-8
     commands:
       - mvn -B -DskipTests clean verify
+      - ./scripts/smoke-javaagent.sh
 
   build-jdk-17:
     image: maven:3.9-eclipse-temurin-17
     commands:
       - mvn -B -DskipTests clean verify
+      - ./scripts/smoke-javaagent.sh
 
   build-jdk-21:
     image: maven:3.9-eclipse-temurin-21
     commands:
       - mvn -B -DskipTests clean verify
+      - ./scripts/smoke-javaagent.sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Download the `keploy-sdk` jar and keep it outside your application dependencies.
           <artifactItem>
             <groupId>io.keploy</groupId>
             <artifactId>keploy-sdk</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.0</version>
             <outputDirectory>${project.build.directory}</outputDirectory>
             <destFileName>keploy-sdk.jar</destFileName>
           </artifactItem>

--- a/README.md
+++ b/README.md
@@ -23,55 +23,41 @@ Coverage is collected at per-testcase granularity, not process granularity.
 
 ## How to Use
 
-### 1. Add the SDK
+### 1. Download the Keploy Java Agent
 
-Add `keploy-sdk` to your application:
-
-```xml
-<dependency>
-  <groupId>io.keploy</groupId>
-  <artifactId>keploy-sdk</artifactId>
-  <version>2.0.0</version>
-</dependency>
-```
-
-### 2. Activate the Agent
-
-For Spring Boot, import the middleware in your application:
-
-```java
-import io.keploy.servlet.KeployMiddleware;
-import org.springframework.context.annotation.Import;
-
-@Import(KeployMiddleware.class)
-public class Application {
-}
-```
-
-For servlet-based applications, register the filter early in `web.xml`:
+Download the `keploy-sdk` jar and keep it outside your application dependencies. The jar is a Java agent and should be attached only when you run Keploy dynamic deduplication.
 
 ```xml
-<filter>
-  <filter-name>middleware</filter-name>
-  <filter-class>io.keploy.servlet.KeployMiddleware</filter-class>
-</filter>
-<filter-mapping>
-  <filter-name>middleware</filter-name>
-  <url-pattern>/*</url-pattern>
-</filter-mapping>
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-dependency-plugin</artifactId>
+  <version>3.6.1</version>
+  <executions>
+    <execution>
+      <id>copy-keploy-java-agent</id>
+      <phase>package</phase>
+      <goals>
+        <goal>copy</goal>
+      </goals>
+      <configuration>
+        <artifactItems>
+          <artifactItem>
+            <groupId>io.keploy</groupId>
+            <artifactId>keploy-sdk</artifactId>
+            <version>2.0.1</version>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <destFileName>keploy-sdk.jar</destFileName>
+          </artifactItem>
+        </artifactItems>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
 ```
 
-The middleware starts the Java dedup control server automatically.
+The SDK no longer has to be added to `dependencies`, and application code should not import `io.keploy.*` classes for dynamic deduplication.
 
-For Jakarta Servlet stacks, non-servlet frameworks, or any application where the `javax.servlet` filter is not available, start the agent directly during application startup:
-
-```java
-import io.keploy.dedup.KeployDedupAgent;
-
-KeployDedupAgent.start();
-```
-
-### 3. Run the App with the JaCoCo Java Agent
+### 2. Run the App with the Keploy and JaCoCo Java Agents
 
 The dedup agent reads coverage in-process via JaCoCo's runtime API (`org.jacoco.agent.rt.RT.getAgent()`), so attaching the JaCoCo Java agent is the only runtime requirement in the common cases below:
 
@@ -79,22 +65,27 @@ The dedup agent reads coverage in-process via JaCoCo's runtime API (`org.jacoco.
 - packaged `java -jar` runs where the application classes live inside the executable jar
 
 ```bash
-java -javaagent:/path/to/jacocoagent.jar -jar your-app.jar
+java \
+  -javaagent:/path/to/keploy-sdk.jar \
+  -javaagent:/path/to/jacocoagent.jar \
+  -jar your-app.jar
 ```
 
 If the in-process API is unavailable (for example because the JaCoCo agent is loaded into an isolated classloader), the SDK transparently falls back to JaCoCo's TCP server mode. To use the fallback explicitly, start JaCoCo in `tcpserver` mode and set `KEPLOY_JACOCO_HOST` / `KEPLOY_JACOCO_PORT`:
 
 ```bash
-java -javaagent:/path/to/jacocoagent.jar=address=127.0.0.1,port=36320,output=tcpserver \
+java \
+  -javaagent:/path/to/keploy-sdk.jar \
+  -javaagent:/path/to/jacocoagent.jar=address=127.0.0.1,port=36320,output=tcpserver \
   -jar your-app.jar
 ```
 
-### 4. Replay with Keploy Enterprise
+### 3. Replay with Keploy Enterprise
 
 Run replay with dynamic dedup enabled:
 
 ```bash
-keploy test -c "java -javaagent:/path/to/jacocoagent.jar -jar your-app.jar" \
+keploy test -c "java -javaagent:/path/to/keploy-sdk.jar -javaagent:/path/to/jacocoagent.jar -jar your-app.jar" \
   --dedup \
   --language java
 ```
@@ -128,8 +119,8 @@ Without a shared `/tmp`, dedup will not work inside containers because Enterpris
 
 - `KEPLOY_JACOCO_HOST`: JaCoCo TCP host used when the in-process runtime API is unavailable. Default: `127.0.0.1`
 - `KEPLOY_JACOCO_PORT`: JaCoCo TCP port used when the in-process runtime API is unavailable. Default: `36320`
-- `KEPLOY_JAVA_CLASS_DIRS`: optional comma-separated class or jar locations to analyze for executed lines when your build output lives outside the standard locations
-- `KEPLOY_JAVA_CLASSPATH_FALLBACK`: scans the full classpath if standard class roots and the executable jar do not provide application classes. Default: `false`
+- `KEPLOY_JAVA_CLASS_DIRS`: optional comma-separated class, jar, war, ear, or zip locations to analyze for executed lines when your build output lives outside the standard locations
+- `KEPLOY_JAVA_CLASSPATH_FALLBACK`: scans the full classpath if standard class roots and the executable archive do not provide application classes. Default: `true`
 - `KEPLOY_JAVA_DEDUP_DISABLED`: disables the Java dedup agent when set to `true`, `1`, or `yes`
 
 ## Sample
@@ -138,4 +129,4 @@ For a working reference, see the Java dedup sample in `keploy/samples-java`:
 
 - `samples-java/java-dedup`
 
-That sample is used in CI to validate Java dynamic dedup for JDK 8, 17, and 21 across native, Docker, and restricted Docker runs.
+That sample is used in CI to validate Java dynamic dedup for JDK 8, 17, and 21 across native, classpath, Docker, distroless, and restricted Docker runs.

--- a/keploy-sdk/pom.xml
+++ b/keploy-sdk/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <artifactId>java-sdk</artifactId>
         <groupId>io.keploy</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>keploy-sdk</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>2.0.0</version>
     <name>Keploy Java Coverage Agent</name>
     <description>Java dynamic dedup coverage agent for Keploy Enterprise</description>
     <url>https://github.com/keploy/java-sdk</url>

--- a/keploy-sdk/pom.xml
+++ b/keploy-sdk/pom.xml
@@ -80,6 +80,48 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <id>shade-java-agent</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Premain-Class>io.keploy.dedup.KeployDedupAgent</Premain-Class>
+                                        <Agent-Class>io.keploy.dedup.KeployDedupAgent</Agent-Class>
+                                        <Can-Redefine-Classes>false</Can-Redefine-Classes>
+                                        <Can-Retransform-Classes>false</Can-Retransform-Classes>
+                                        <Implementation-Title>${project.name}</Implementation-Title>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Automatic-Module-Name>io.keploy.sdk</Automatic-Module-Name>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.4.1</version>
                 <executions>

--- a/keploy-sdk/src/main/java/io/keploy/dedup/KeployDedupAgent.java
+++ b/keploy-sdk/src/main/java/io/keploy/dedup/KeployDedupAgent.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.lang.instrument.Instrumentation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
@@ -39,6 +40,7 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,9 +67,30 @@ public final class KeployDedupAgent {
     private static final int SOCKET_BACKLOG = 50;
 
     private static final AtomicBoolean STARTED = new AtomicBoolean(false);
+    private static final AtomicBoolean SHUTDOWN_HOOK_REGISTERED = new AtomicBoolean(false);
     private static volatile CommandServer commandServer;
 
     private KeployDedupAgent() {
+    }
+
+    /**
+     * JVM entrypoint used when the SDK is attached with {@code -javaagent}.
+     *
+     * @param agentArgs optional Java agent arguments
+     * @param instrumentation JVM instrumentation handle
+     */
+    public static void premain(String agentArgs, Instrumentation instrumentation) {
+        start();
+    }
+
+    /**
+     * JVM entrypoint used when the SDK is attached to an already running JVM.
+     *
+     * @param agentArgs optional Java agent arguments
+     * @param instrumentation JVM instrumentation handle
+     */
+    public static void agentmain(String agentArgs, Instrumentation instrumentation) {
+        start();
     }
 
     /**
@@ -91,6 +114,7 @@ public final class KeployDedupAgent {
         thread.setDaemon(true);
         commandServer = server;
         thread.start();
+        registerShutdownHook();
         return true;
     }
 
@@ -118,6 +142,22 @@ public final class KeployDedupAgent {
     private static boolean isDisabled() {
         return isTruthy(System.getenv("KEPLOY_JAVA_DEDUP_DISABLED"))
                 || isTruthy(System.getProperty("keploy.java.dedup.disabled"));
+    }
+
+    private static void registerShutdownHook() {
+        if (!SHUTDOWN_HOOK_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    KeployDedupAgent.stop();
+                }
+            }, "keploy-java-dedup-shutdown"));
+        } catch (IllegalStateException ignored) {
+            // The VM is already shutting down; the process exit will reclaim resources.
+        }
     }
 
     private static boolean diagnosticsEnabled() {
@@ -802,13 +842,13 @@ public final class KeployDedupAgent {
 
         private boolean isClasspathFallbackEnabled() {
             return isTruthy(envOrProperty("KEPLOY_JAVA_CLASSPATH_FALLBACK",
-                    "keploy.java.classpath.fallback", "false"));
+                    "keploy.java.classpath.fallback", "true"));
         }
 
         private List<File> executableArchiveRoots() {
             LinkedHashSet<File> roots = new LinkedHashSet<>();
 
-            addJarRoot(roots, firstCommandToken(System.getProperty("sun.java.command", "")));
+            addArchiveRoot(roots, firstCommandToken(System.getProperty("sun.java.command", "")));
 
             String classpath = System.getProperty("java.class.path", "");
             if (classpath.trim().isEmpty()) {
@@ -817,12 +857,12 @@ public final class KeployDedupAgent {
 
             String[] parts = classpath.split(Pattern.quote(File.pathSeparator));
             if (parts.length == 1) {
-                addJarRoot(roots, parts[0]);
+                addArchiveRoot(roots, parts[0]);
             }
             return new ArrayList<>(roots);
         }
 
-        private void addJarRoot(Set<File> roots, String rawPath) {
+        private void addArchiveRoot(Set<File> roots, String rawPath) {
             if (rawPath == null) {
                 return;
             }
@@ -836,9 +876,17 @@ public final class KeployDedupAgent {
             if (!file.isAbsolute()) {
                 file = new File(System.getProperty("user.dir"), path);
             }
-            if (file.isFile() && file.getName().endsWith(".jar")) {
+            if (file.isFile() && isArchive(file)) {
                 roots.add(file);
             }
+        }
+
+        private boolean isArchive(File file) {
+            String name = file.getName().toLowerCase(Locale.ROOT);
+            return name.endsWith(".jar")
+                    || name.endsWith(".war")
+                    || name.endsWith(".ear")
+                    || name.endsWith(".zip");
         }
 
         private String firstCommandToken(String command) {
@@ -879,7 +927,7 @@ public final class KeployDedupAgent {
                 for (String part : parts) {
                     if (!part.trim().isEmpty()) {
                         File file = new File(part.trim());
-                        if (file.isDirectory() || file.getName().endsWith(".jar")) {
+                        if (file.isDirectory() || isArchive(file)) {
                             roots.add(file);
                         }
                     }
@@ -895,7 +943,7 @@ public final class KeployDedupAgent {
                 }
                 if (root.isDirectory()) {
                     scanDirectory(root, output);
-                } else if (root.isFile() && root.getName().endsWith(".jar")) {
+                } else if (root.isFile() && isArchive(root)) {
                     scanJar(root, output);
                 }
             }
@@ -972,6 +1020,12 @@ public final class KeployDedupAgent {
         private boolean shouldSkipClass(String name) {
             return name.endsWith("module-info.class")
                     || name.endsWith("package-info.class")
+                    || name.startsWith("io/keploy/dedup/")
+                    || name.startsWith("io/keploy/servlet/")
+                    || name.startsWith("org/jacoco/")
+                    || name.startsWith("org/objectweb/asm/")
+                    || name.startsWith("org/newsclub/net/unix/")
+                    || name.startsWith("com/google/gson/")
                     || name.contains("$Mockito")
                     || name.contains("Test.class");
         }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.keploy</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
 
     <name>Keploy Java Coverage Agent</name>

--- a/scripts/smoke-javaagent.sh
+++ b/scripts/smoke-javaagent.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+module_dir="${repo_root}/keploy-sdk"
+mkdir -p "${module_dir}/target"
+agent_jar="$(find "${module_dir}/target" -maxdepth 1 -type f -name 'keploy-sdk-*.jar' \
+  ! -name 'original-*' ! -name '*-sources.jar' ! -name '*-javadoc.jar' | sort | head -n 1)"
+
+if [[ -z "${agent_jar}" || ! -f "${agent_jar}" ]]; then
+  echo "Missing agent jar under ${module_dir}/target" >&2
+  echo "Run mvn -B -DskipTests package first." >&2
+  exit 1
+fi
+
+mvn -q -f "${repo_root}/pom.xml" org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy \
+  -Dartifact=org.jacoco:org.jacoco.agent:0.8.12:jar:runtime \
+  -DoutputDirectory="${module_dir}/target" \
+  -DdestFileName=jacocoagent.jar
+
+jacoco_jar="$(find "${module_dir}/target" -maxdepth 1 -type f \( \
+  -name 'jacocoagent.jar' -o -name 'org.jacoco.agent-*-runtime.jar' \) | sort | head -n 1)"
+if [[ -z "${jacoco_jar}" || ! -f "${jacoco_jar}" ]]; then
+  echo "Missing JaCoCo runtime agent jar under ${module_dir}/target" >&2
+  exit 1
+fi
+
+work_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${work_dir}"
+  rm -f /tmp/coverage_control.sock /tmp/coverage_data.sock /tmp/keploy-sdk-smoke-*.exec
+}
+trap cleanup EXIT
+
+mkdir -p "${work_dir}/src/smoke" "${work_dir}/classes"
+
+cat > "${work_dir}/src/smoke/Work.java" <<'JAVA'
+package smoke;
+
+final class Work {
+    private Work() {
+    }
+
+    static int exercise(int input) {
+        int value = input + 1;
+        if (value > 1) {
+            value = value * 2;
+        }
+        return value;
+    }
+}
+JAVA
+
+cat > "${work_dir}/src/smoke/SmokeHarness.java" <<'JAVA'
+package smoke;
+
+import org.newsclub.net.unix.AFUNIXServerSocket;
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class SmokeHarness {
+    private static final File CONTROL_SOCKET = new File("/tmp/coverage_control.sock");
+    private static final File DATA_SOCKET = new File("/tmp/coverage_data.sock");
+
+    public static void main(String[] args) throws Exception {
+        String mode = args.length == 0 ? "unknown" : args[0];
+        delete(DATA_SOCKET);
+
+        AtomicReference<String> payload = new AtomicReference<String>();
+        CountDownLatch received = new CountDownLatch(1);
+        Thread receiver = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try (AFUNIXServerSocket server = AFUNIXServerSocket.newInstance()) {
+                    server.bind(AFUNIXSocketAddress.of(DATA_SOCKET), 1);
+                    try (AFUNIXSocket socket = server.accept()) {
+                        payload.set(readAll(socket.getInputStream()));
+                        received.countDown();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }, "coverage-data-receiver");
+        receiver.setDaemon(true);
+        receiver.start();
+
+        waitFor(CONTROL_SOCKET);
+        waitFor(DATA_SOCKET);
+
+        command("START test-set-0/" + mode);
+        if (Work.exercise(1) != 4) {
+            throw new IllegalStateException("unexpected application result");
+        }
+        command("END test-set-0/" + mode);
+
+        if (!received.await(10, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("timed out waiting for coverage payload in " + mode);
+        }
+
+        String json = payload.get();
+        if (json == null
+                || !json.contains("\"id\":\"test-set-0/" + mode + "\"")
+                || !json.contains("Work.java")) {
+            throw new IllegalStateException("unexpected coverage payload for " + mode + ": " + json);
+        }
+        System.out.println(mode + ": " + json);
+    }
+
+    private static void command(String command) throws Exception {
+        try (AFUNIXSocket socket = AFUNIXSocket.newInstance()) {
+            socket.connect(AFUNIXSocketAddress.of(CONTROL_SOCKET), 3000);
+            OutputStream output = socket.getOutputStream();
+            output.write((command + "\n").getBytes(StandardCharsets.UTF_8));
+            output.flush();
+            String ack = readAll(socket.getInputStream());
+            if (!ack.contains("ACK")) {
+                throw new IllegalStateException("missing ACK for " + command + ": " + ack);
+            }
+        }
+    }
+
+    private static void waitFor(File file) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10000L;
+        while (System.currentTimeMillis() < deadline) {
+            if (file.exists()) {
+                return;
+            }
+            Thread.sleep(50L);
+        }
+        throw new IllegalStateException("timed out waiting for " + file);
+    }
+
+    private static String readAll(InputStream input) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            output.write(buffer, 0, read);
+        }
+        return new String(output.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static void delete(File file) {
+        if (file.exists() && !file.delete()) {
+            throw new IllegalStateException("failed to delete " + file);
+        }
+    }
+}
+JAVA
+
+javac -cp "${agent_jar}" -d "${work_dir}/classes" \
+  "${work_dir}/src/smoke/Work.java" \
+  "${work_dir}/src/smoke/SmokeHarness.java"
+
+run_smoke() {
+  local mode="${1:?mode required}"
+  shift
+
+  echo "Running Java agent smoke: ${mode}"
+  rm -f /tmp/coverage_control.sock /tmp/coverage_data.sock "/tmp/keploy-sdk-smoke-${mode}.exec"
+  "$@"
+}
+
+java_with_agents() {
+  local mode="${1:?mode required}"
+  shift
+
+  java \
+    -javaagent:"${agent_jar}" \
+    -javaagent:"${jacoco_jar}=destfile=/tmp/keploy-sdk-smoke-${mode}.exec" \
+    "$@"
+}
+
+mkdir -p "${work_dir}/maven/target/classes" "${work_dir}/gradle/build/classes/java/main"
+cp -R "${work_dir}/classes/." "${work_dir}/maven/target/classes/"
+cp -R "${work_dir}/classes/." "${work_dir}/gradle/build/classes/java/main/"
+
+(
+  cd "${work_dir}/maven"
+  run_smoke "maven-classes" \
+    java_with_agents "maven-classes" \
+      -cp "target/classes:${agent_jar}" \
+      smoke.SmokeHarness "maven-classes"
+)
+
+(
+  cd "${work_dir}/gradle"
+  run_smoke "gradle-classes" \
+    java_with_agents "gradle-classes" \
+      -cp "build/classes/java/main:${agent_jar}" \
+      smoke.SmokeHarness "gradle-classes"
+)
+
+run_smoke "classpath-fallback" \
+  java_with_agents "classpath-fallback" \
+    -cp "${work_dir}/classes:${agent_jar}" \
+    smoke.SmokeHarness "classpath-fallback"
+
+mkdir -p "${work_dir}/jar/lib"
+cp "${agent_jar}" "${work_dir}/jar/lib/keploy-sdk.jar"
+cat > "${work_dir}/jar/MANIFEST.MF" <<EOF
+Manifest-Version: 1.0
+Main-Class: smoke.SmokeHarness
+Class-Path: lib/keploy-sdk.jar
+
+EOF
+jar cfm "${work_dir}/jar/plain-app.jar" "${work_dir}/jar/MANIFEST.MF" -C "${work_dir}/classes" .
+(
+  cd "${work_dir}/jar"
+  run_smoke "plain-jar" \
+    java_with_agents "plain-jar" \
+      -jar plain-app.jar "plain-jar"
+)
+
+mkdir -p "${work_dir}/boot-root/BOOT-INF/classes" "${work_dir}/war-root/WEB-INF/classes"
+cp -R "${work_dir}/classes/." "${work_dir}/boot-root/BOOT-INF/classes/"
+cp -R "${work_dir}/classes/." "${work_dir}/war-root/WEB-INF/classes/"
+jar cf "${work_dir}/spring-boot-layout.jar" -C "${work_dir}/boot-root" .
+jar cf "${work_dir}/servlet-layout.war" -C "${work_dir}/war-root" .
+
+KEPLOY_JAVA_CLASS_DIRS="${work_dir}/spring-boot-layout.jar" \
+run_smoke "spring-boot-layout" \
+  java_with_agents "spring-boot-layout" \
+    -cp "${work_dir}/classes:${agent_jar}" \
+    smoke.SmokeHarness "spring-boot-layout"
+
+KEPLOY_JAVA_CLASS_DIRS="${work_dir}/servlet-layout.war" \
+run_smoke "servlet-war-layout" \
+  java_with_agents "servlet-war-layout" \
+    -cp "${work_dir}/classes:${agent_jar}" \
+    smoke.SmokeHarness "servlet-war-layout"


### PR DESCRIPTION
## Related Issue
- NA

#### Describe the changes you've made
Adds Java-agent support to the Keploy Java SDK so Java dynamic dedup can run without application code importing or compiling against Keploy classes.

Key changes:
- Prepares `io.keploy:keploy-sdk:2.0.0` as the Java agent artifact.
- Adds `premain` and `agentmain` entrypoints for `-javaagent` usage.
- Adds Java agent manifest attributes for `Premain-Class` and `Agent-Class`.
- Keeps the existing coverage socket protocol and JaCoCo integration behind the agent.
- Supports class discovery for Maven/Gradle output, classpath entries, plain jars, Spring Boot jars, servlet/WAR layouts, and custom class directories.
- Keeps Keploy SDK internals out of coverage while still allowing application packages under `io.keploy.*` to be analyzed.
- Adds a Java-agent smoke script that validates the supported launch and archive layouts.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How did you test your code changes?
- `mvn -B -DskipTests package`
- `./scripts/smoke-javaagent.sh`
- `git diff HEAD^ HEAD --check`
- The smoke script verifies Java-agent startup, per-test coverage capture, and class discovery across Maven, Gradle, classpath fallback, plain jar, Spring Boot layout, and servlet/WAR layout.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas and used java doc.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added smoke coverage that proves the feature works.

## Screenshots (if any)
NA
